### PR TITLE
fix(zoneInfo-not-set-bug): use for loop zone

### DIFF
--- a/dnssvcsv1/dns_svcs_v1_integration_test.go
+++ b/dnssvcsv1/dns_svcs_v1_integration_test.go
@@ -210,7 +210,7 @@ var _ = Describe(`dnssvcsv1`, func() {
 					if strings.Contains(*zone.Name, "test-example") {
 
 						// First delete PTR record to avoid any record linking issue
-						listOptions2 := service.NewListResourceRecordsOptions(instanceID, *zoneInfo.ID)
+						listOptions2 := service.NewListResourceRecordsOptions(instanceID, *zone.ID)
 						listOptions2.SetType("PTR")
 						listResult2, _, listErr2 := service.ListResourceRecords(listOptions2)
 						Expect(listErr2).To(BeNil())
@@ -274,7 +274,7 @@ var _ = Describe(`dnssvcsv1`, func() {
 					if strings.Contains(*zone.Name, "test-example") {
 
 						// First delete PTR record to avoid any record linking issue
-						listOptions2 := service.NewListResourceRecordsOptions(instanceID, *zoneInfo.ID)
+						listOptions2 := service.NewListResourceRecordsOptions(instanceID, *zone.ID)
 						listOptions2.SetType("PTR")
 						listResult2, _, listErr2 := service.ListResourceRecords(listOptions2)
 						Expect(listErr2).To(BeNil())


### PR DESCRIPTION
## PR summary
Before running resourcerecordsv1 specs (integration tests), uncleaned resources from previous integration test runs must be cleaned up first. This is done through Context's BeforeEach function.
The BeforeEach function loops through the existing zones, deletes the DNS records for each test zone, and lastly, deletes the test zone itself. Once this is done, a new test zone is created and stored in the Context variable zoneInfo. This zone is used to execute CRUD tests related to resource records. This variable is not set until after all stranded/ghost resources have been deleted. A panic was executed in a post-merge PR build in the network SDK public repo: https://app.travis-ci.com/github/IBM/networking-go-sdk/jobs/604489828
This panic was caused because the field zoneInfo.Id was being accessed before the zoneInfo variable was set.
zoneInfo needs to be changed to use the zone in the loop instead.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->