### PR TITLE
chore: SDK version update from v0.44.0 to v0.45.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.44.0
+current_version = 0.45.0
 commit = True
 message = Update version {current_version} -> {new_version} [skip ci]
 

--- a/common/version.go
+++ b/common/version.go
@@ -17,4 +17,4 @@
 package common
 
 // Version of the SDK
-const Version = "0.44.0"
+const Version = "0.45.0"


### PR DESCRIPTION
The semantic-release-bot did not run to make the required changes in the `common/version.go`  and .`bumpversion.cfg ` files with the updated version. They still show v0.44.0 . This is failing sematic-release in Travis build.
Hence making a manual commit to update them.