### PR TITLE
feat(directlink): Support Secrets Manager CRNs for authentication_key

### DIFF
--- a/directlinkv1/direct_link_v1.go
+++ b/directlinkv1/direct_link_v1.go
@@ -737,7 +737,7 @@ func (directLink *DirectLinkV1) CreateGatewayCompletionNoticeWithContext(ctx con
 		err = core.SDKErrorf(err, "", "struct-validation-error", common.GetComponentInfo())
 		return
 	}
-	if (createGatewayCompletionNoticeOptions.Upload == nil) {
+	if createGatewayCompletionNoticeOptions.Upload == nil {
 		err = core.SDKErrorf(nil, "upload must be supplied", "condition-not-met", common.GetComponentInfo())
 		return
 	}
@@ -1447,7 +1447,7 @@ func (directLink *DirectLinkV1) DeleteGatewayExportRouteFilterWithContext(ctx co
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *deleteGatewayExportRouteFilterOptions.GatewayID,
-		"id": *deleteGatewayExportRouteFilterOptions.ID,
+		"id":         *deleteGatewayExportRouteFilterOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
@@ -1509,7 +1509,7 @@ func (directLink *DirectLinkV1) GetGatewayExportRouteFilterWithContext(ctx conte
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *getGatewayExportRouteFilterOptions.GatewayID,
-		"id": *getGatewayExportRouteFilterOptions.ID,
+		"id":         *getGatewayExportRouteFilterOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -1589,7 +1589,7 @@ func (directLink *DirectLinkV1) UpdateGatewayExportRouteFilterWithContext(ctx co
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *updateGatewayExportRouteFilterOptions.GatewayID,
-		"id": *updateGatewayExportRouteFilterOptions.ID,
+		"id":         *updateGatewayExportRouteFilterOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.PATCH)
@@ -1938,7 +1938,7 @@ func (directLink *DirectLinkV1) DeleteGatewayImportRouteFilterWithContext(ctx co
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *deleteGatewayImportRouteFilterOptions.GatewayID,
-		"id": *deleteGatewayImportRouteFilterOptions.ID,
+		"id":         *deleteGatewayImportRouteFilterOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
@@ -2000,7 +2000,7 @@ func (directLink *DirectLinkV1) GetGatewayImportRouteFilterWithContext(ctx conte
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *getGatewayImportRouteFilterOptions.GatewayID,
-		"id": *getGatewayImportRouteFilterOptions.ID,
+		"id":         *getGatewayImportRouteFilterOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -2080,7 +2080,7 @@ func (directLink *DirectLinkV1) UpdateGatewayImportRouteFilterWithContext(ctx co
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *updateGatewayImportRouteFilterOptions.GatewayID,
-		"id": *updateGatewayImportRouteFilterOptions.ID,
+		"id":         *updateGatewayImportRouteFilterOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.PATCH)
@@ -2624,7 +2624,7 @@ func (directLink *DirectLinkV1) DeleteGatewayMacsecCakWithContext(ctx context.Co
 	}
 
 	pathParamsMap := map[string]string{
-		"id": *deleteGatewayMacsecCakOptions.ID,
+		"id":     *deleteGatewayMacsecCakOptions.ID,
 		"cak_id": *deleteGatewayMacsecCakOptions.CakID,
 	}
 
@@ -2686,7 +2686,7 @@ func (directLink *DirectLinkV1) GetGatewayMacsecCakWithContext(ctx context.Conte
 	}
 
 	pathParamsMap := map[string]string{
-		"id": *getGatewayMacsecCakOptions.ID,
+		"id":     *getGatewayMacsecCakOptions.ID,
 		"cak_id": *getGatewayMacsecCakOptions.CakID,
 	}
 
@@ -2758,7 +2758,7 @@ func (directLink *DirectLinkV1) UpdateGatewayMacsecCakWithContext(ctx context.Co
 	}
 
 	pathParamsMap := map[string]string{
-		"id": *updateGatewayMacsecCakOptions.ID,
+		"id":     *updateGatewayMacsecCakOptions.ID,
 		"cak_id": *updateGatewayMacsecCakOptions.CakID,
 	}
 
@@ -2984,7 +2984,7 @@ func (directLink *DirectLinkV1) DeleteGatewayRouteReportWithContext(ctx context.
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *deleteGatewayRouteReportOptions.GatewayID,
-		"id": *deleteGatewayRouteReportOptions.ID,
+		"id":         *deleteGatewayRouteReportOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
@@ -3046,7 +3046,7 @@ func (directLink *DirectLinkV1) GetGatewayRouteReportWithContext(ctx context.Con
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *getGatewayRouteReportOptions.GatewayID,
-		"id": *getGatewayRouteReportOptions.ID,
+		"id":         *getGatewayRouteReportOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -3278,7 +3278,7 @@ func (directLink *DirectLinkV1) DeleteGatewayVirtualConnectionWithContext(ctx co
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *deleteGatewayVirtualConnectionOptions.GatewayID,
-		"id": *deleteGatewayVirtualConnectionOptions.ID,
+		"id":         *deleteGatewayVirtualConnectionOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
@@ -3340,7 +3340,7 @@ func (directLink *DirectLinkV1) GetGatewayVirtualConnectionWithContext(ctx conte
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *getGatewayVirtualConnectionOptions.GatewayID,
-		"id": *getGatewayVirtualConnectionOptions.ID,
+		"id":         *getGatewayVirtualConnectionOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -3412,7 +3412,7 @@ func (directLink *DirectLinkV1) UpdateGatewayVirtualConnectionWithContext(ctx co
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *updateGatewayVirtualConnectionOptions.GatewayID,
-		"id": *updateGatewayVirtualConnectionOptions.ID,
+		"id":         *updateGatewayVirtualConnectionOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.PATCH)
@@ -4115,6 +4115,7 @@ type AuthenticationKeyIdentity struct {
 	// The CRN of the key.
 	Crn *string `json:"crn,omitempty"`
 }
+
 func (*AuthenticationKeyIdentity) isaAuthenticationKeyIdentity() bool {
 	return true
 }
@@ -4155,6 +4156,7 @@ type AuthenticationKeyReference struct {
 	// The CRN of the referenced key.
 	Crn *string `json:"crn,omitempty"`
 }
+
 func (*AuthenticationKeyReference) isaAuthenticationKeyReference() bool {
 	return true
 }
@@ -4238,12 +4240,12 @@ type CreateGatewayActionOptions struct {
 // Constants associated with the CreateGatewayActionOptions.Action property.
 // Action request.
 const (
-	CreateGatewayActionOptions_Action_CreateGatewayApprove = "create_gateway_approve"
-	CreateGatewayActionOptions_Action_CreateGatewayReject = "create_gateway_reject"
-	CreateGatewayActionOptions_Action_DeleteGatewayApprove = "delete_gateway_approve"
-	CreateGatewayActionOptions_Action_DeleteGatewayReject = "delete_gateway_reject"
+	CreateGatewayActionOptions_Action_CreateGatewayApprove    = "create_gateway_approve"
+	CreateGatewayActionOptions_Action_CreateGatewayReject     = "create_gateway_reject"
+	CreateGatewayActionOptions_Action_DeleteGatewayApprove    = "delete_gateway_approve"
+	CreateGatewayActionOptions_Action_DeleteGatewayReject     = "delete_gateway_reject"
 	CreateGatewayActionOptions_Action_UpdateAttributesApprove = "update_attributes_approve"
-	CreateGatewayActionOptions_Action_UpdateAttributesReject = "update_attributes_reject"
+	CreateGatewayActionOptions_Action_UpdateAttributesReject  = "update_attributes_reject"
 )
 
 // Constants associated with the CreateGatewayActionOptions.ConnectionMode property.
@@ -4253,21 +4255,21 @@ const (
 // list of enumerated values for this property may expand in the future. Code and processes using this field must
 // tolerate unexpected values.
 const (
-	CreateGatewayActionOptions_ConnectionMode_Direct = "direct"
+	CreateGatewayActionOptions_ConnectionMode_Direct  = "direct"
 	CreateGatewayActionOptions_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the CreateGatewayActionOptions.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	CreateGatewayActionOptions_DefaultExportRouteFilter_Deny = "deny"
+	CreateGatewayActionOptions_DefaultExportRouteFilter_Deny   = "deny"
 	CreateGatewayActionOptions_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the CreateGatewayActionOptions.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	CreateGatewayActionOptions_DefaultImportRouteFilter_Deny = "deny"
+	CreateGatewayActionOptions_DefaultImportRouteFilter_Deny   = "deny"
 	CreateGatewayActionOptions_DefaultImportRouteFilter_Permit = "permit"
 )
 
@@ -4449,7 +4451,7 @@ type CreateGatewayExportRouteFilterOptions struct {
 // Constants associated with the CreateGatewayExportRouteFilterOptions.Action property.
 // Determines whether routes that match the prefix-set will be allowed (permit) or rejected (deny) through the filter.
 const (
-	CreateGatewayExportRouteFilterOptions_Action_Deny = "deny"
+	CreateGatewayExportRouteFilterOptions_Action_Deny   = "deny"
 	CreateGatewayExportRouteFilterOptions_Action_Permit = "permit"
 )
 
@@ -4457,8 +4459,8 @@ const (
 func (*DirectLinkV1) NewCreateGatewayExportRouteFilterOptions(gatewayID string, action string, prefix string) *CreateGatewayExportRouteFilterOptions {
 	return &CreateGatewayExportRouteFilterOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		Action: core.StringPtr(action),
-		Prefix: core.StringPtr(prefix),
+		Action:    core.StringPtr(action),
+		Prefix:    core.StringPtr(prefix),
 	}
 }
 
@@ -4539,7 +4541,7 @@ type CreateGatewayImportRouteFilterOptions struct {
 // Constants associated with the CreateGatewayImportRouteFilterOptions.Action property.
 // Determines whether routes that match the prefix-set will be allowed (permit) or rejected (deny) through the filter.
 const (
-	CreateGatewayImportRouteFilterOptions_Action_Deny = "deny"
+	CreateGatewayImportRouteFilterOptions_Action_Deny   = "deny"
 	CreateGatewayImportRouteFilterOptions_Action_Permit = "permit"
 )
 
@@ -4547,8 +4549,8 @@ const (
 func (*DirectLinkV1) NewCreateGatewayImportRouteFilterOptions(gatewayID string, action string, prefix string) *CreateGatewayImportRouteFilterOptions {
 	return &CreateGatewayImportRouteFilterOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		Action: core.StringPtr(action),
-		Prefix: core.StringPtr(prefix),
+		Action:    core.StringPtr(action),
+		Prefix:    core.StringPtr(prefix),
 	}
 }
 
@@ -4629,15 +4631,15 @@ type CreateGatewayMacsecCakOptions struct {
 // There must be a `primary` session CAK. A `fallback` CAK is optional.
 const (
 	CreateGatewayMacsecCakOptions_Session_Fallback = "fallback"
-	CreateGatewayMacsecCakOptions_Session_Primary = "primary"
+	CreateGatewayMacsecCakOptions_Session_Primary  = "primary"
 )
 
 // NewCreateGatewayMacsecCakOptions : Instantiate CreateGatewayMacsecCakOptions
 func (*DirectLinkV1) NewCreateGatewayMacsecCakOptions(id string, key GatewayMacsecCakKeyReferenceIntf, name string, session string) *CreateGatewayMacsecCakOptions {
 	return &CreateGatewayMacsecCakOptions{
-		ID: core.StringPtr(id),
-		Key: key,
-		Name: core.StringPtr(name),
+		ID:      core.StringPtr(id),
+		Key:     key,
+		Name:    core.StringPtr(name),
 		Session: core.StringPtr(session),
 	}
 }
@@ -4752,15 +4754,15 @@ type CreateGatewayVirtualConnectionOptions struct {
 // The type of virtual connection.
 const (
 	CreateGatewayVirtualConnectionOptions_Type_Classic = "classic"
-	CreateGatewayVirtualConnectionOptions_Type_Vpc = "vpc"
+	CreateGatewayVirtualConnectionOptions_Type_Vpc     = "vpc"
 )
 
 // NewCreateGatewayVirtualConnectionOptions : Instantiate CreateGatewayVirtualConnectionOptions
 func (*DirectLinkV1) NewCreateGatewayVirtualConnectionOptions(gatewayID string, name string, typeVar string) *CreateGatewayVirtualConnectionOptions {
 	return &CreateGatewayVirtualConnectionOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		Name: core.StringPtr(name),
-		Type: core.StringPtr(typeVar),
+		Name:      core.StringPtr(name),
+		Type:      core.StringPtr(typeVar),
 	}
 }
 
@@ -4847,7 +4849,7 @@ type DeleteGatewayExportRouteFilterOptions struct {
 func (*DirectLinkV1) NewDeleteGatewayExportRouteFilterOptions(gatewayID string, id string) *DeleteGatewayExportRouteFilterOptions {
 	return &DeleteGatewayExportRouteFilterOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID: core.StringPtr(id),
+		ID:        core.StringPtr(id),
 	}
 }
 
@@ -4885,7 +4887,7 @@ type DeleteGatewayImportRouteFilterOptions struct {
 func (*DirectLinkV1) NewDeleteGatewayImportRouteFilterOptions(gatewayID string, id string) *DeleteGatewayImportRouteFilterOptions {
 	return &DeleteGatewayImportRouteFilterOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID: core.StringPtr(id),
+		ID:        core.StringPtr(id),
 	}
 }
 
@@ -4922,7 +4924,7 @@ type DeleteGatewayMacsecCakOptions struct {
 // NewDeleteGatewayMacsecCakOptions : Instantiate DeleteGatewayMacsecCakOptions
 func (*DirectLinkV1) NewDeleteGatewayMacsecCakOptions(id string, cakID string) *DeleteGatewayMacsecCakOptions {
 	return &DeleteGatewayMacsecCakOptions{
-		ID: core.StringPtr(id),
+		ID:    core.StringPtr(id),
 		CakID: core.StringPtr(cakID),
 	}
 }
@@ -4989,7 +4991,7 @@ type DeleteGatewayRouteReportOptions struct {
 func (*DirectLinkV1) NewDeleteGatewayRouteReportOptions(gatewayID string, id string) *DeleteGatewayRouteReportOptions {
 	return &DeleteGatewayRouteReportOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID: core.StringPtr(id),
+		ID:        core.StringPtr(id),
 	}
 }
 
@@ -5027,7 +5029,7 @@ type DeleteGatewayVirtualConnectionOptions struct {
 func (*DirectLinkV1) NewDeleteGatewayVirtualConnectionOptions(gatewayID string, id string) *DeleteGatewayVirtualConnectionOptions {
 	return &DeleteGatewayVirtualConnectionOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID: core.StringPtr(id),
+		ID:        core.StringPtr(id),
 	}
 }
 
@@ -5215,10 +5217,10 @@ type Gateway struct {
 // Gateway BGP status. The list of enumerated values for this property may expand in the future. Code and processes
 // using this field  must tolerate unexpected values.
 const (
-	Gateway_BgpStatus_Active = "active"
-	Gateway_BgpStatus_Connect = "connect"
+	Gateway_BgpStatus_Active      = "active"
+	Gateway_BgpStatus_Connect     = "connect"
 	Gateway_BgpStatus_Established = "established"
-	Gateway_BgpStatus_Idle = "idle"
+	Gateway_BgpStatus_Idle        = "idle"
 )
 
 // Constants associated with the Gateway.ConnectionMode property.
@@ -5226,21 +5228,21 @@ const (
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	Gateway_ConnectionMode_Direct = "direct"
+	Gateway_ConnectionMode_Direct  = "direct"
 	Gateway_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the Gateway.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	Gateway_DefaultExportRouteFilter_Deny = "deny"
+	Gateway_DefaultExportRouteFilter_Deny   = "deny"
 	Gateway_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the Gateway.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	Gateway_DefaultImportRouteFilter_Deny = "deny"
+	Gateway_DefaultImportRouteFilter_Deny   = "deny"
 	Gateway_DefaultImportRouteFilter_Permit = "permit"
 )
 
@@ -5249,7 +5251,7 @@ const (
 // expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
 	Gateway_LinkStatus_Down = "down"
-	Gateway_LinkStatus_Up = "up"
+	Gateway_LinkStatus_Up   = "up"
 )
 
 // Constants associated with the Gateway.MacsecCapability property.
@@ -5263,9 +5265,9 @@ const (
 // - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 // direct link creation.
 const (
-	Gateway_MacsecCapability_Macsec = "macsec"
+	Gateway_MacsecCapability_Macsec         = "macsec"
 	Gateway_MacsecCapability_MacsecOptional = "macsec_optional"
-	Gateway_MacsecCapability_NonMacsec = "non_macsec"
+	Gateway_MacsecCapability_NonMacsec      = "non_macsec"
 )
 
 // Constants associated with the Gateway.OperationalStatus property.
@@ -5275,26 +5277,26 @@ const (
 // See `operational_status_reasons[]` for possible remediation of the `failed` `operational_status`.
 const (
 	Gateway_OperationalStatus_AwaitingCompletionNotice = "awaiting_completion_notice"
-	Gateway_OperationalStatus_AwaitingLoa = "awaiting_loa"
+	Gateway_OperationalStatus_AwaitingLoa              = "awaiting_loa"
 	Gateway_OperationalStatus_CompletionNoticeApproved = "completion_notice_approved"
 	Gateway_OperationalStatus_CompletionNoticeReceived = "completion_notice_received"
 	Gateway_OperationalStatus_CompletionNoticeRejected = "completion_notice_rejected"
-	Gateway_OperationalStatus_Configuring = "configuring"
-	Gateway_OperationalStatus_CreatePending = "create_pending"
-	Gateway_OperationalStatus_CreateRejected = "create_rejected"
-	Gateway_OperationalStatus_DeletePending = "delete_pending"
-	Gateway_OperationalStatus_Failed = "failed"
-	Gateway_OperationalStatus_LoaAccepted = "loa_accepted"
-	Gateway_OperationalStatus_LoaCreated = "loa_created"
-	Gateway_OperationalStatus_LoaRejected = "loa_rejected"
-	Gateway_OperationalStatus_Provisioned = "provisioned"
+	Gateway_OperationalStatus_Configuring              = "configuring"
+	Gateway_OperationalStatus_CreatePending            = "create_pending"
+	Gateway_OperationalStatus_CreateRejected           = "create_rejected"
+	Gateway_OperationalStatus_DeletePending            = "delete_pending"
+	Gateway_OperationalStatus_Failed                   = "failed"
+	Gateway_OperationalStatus_LoaAccepted              = "loa_accepted"
+	Gateway_OperationalStatus_LoaCreated               = "loa_created"
+	Gateway_OperationalStatus_LoaRejected              = "loa_rejected"
+	Gateway_OperationalStatus_Provisioned              = "provisioned"
 )
 
 // Constants associated with the Gateway.Type property.
 // Offering type. The list of enumerated values for this property may expand in the future. Code and processes using
 // this field  must tolerate unexpected values.
 const (
-	Gateway_Type_Connect = "connect"
+	Gateway_Type_Connect   = "connect"
 	Gateway_Type_Dedicated = "dedicated"
 )
 
@@ -5540,6 +5542,7 @@ type GatewayActionTemplateUpdatesItem struct {
 	// VLAN to be updated for this gateway.
 	Vlan *int64 `json:"vlan,omitempty"`
 }
+
 func (*GatewayActionTemplateUpdatesItem) isaGatewayActionTemplateUpdatesItem() bool {
 	return true
 }
@@ -5603,7 +5606,7 @@ type GatewayBfdConfig struct {
 const (
 	GatewayBfdConfig_BfdStatus_Down = "down"
 	GatewayBfdConfig_BfdStatus_Init = "init"
-	GatewayBfdConfig_BfdStatus_Up = "up"
+	GatewayBfdConfig_BfdStatus_Up   = "up"
 )
 
 // UnmarshalGatewayBfdConfig unmarshals an instance of GatewayBfdConfig from the specified map of raw messages.
@@ -5771,6 +5774,7 @@ type GatewayChangeRequest struct {
 const (
 	GatewayChangeRequest_Type_CreateGateway = "create_gateway"
 )
+
 func (*GatewayChangeRequest) isaGatewayChangeRequest() bool {
 	return true
 }
@@ -5831,6 +5835,7 @@ type GatewayChangeRequestGatewayClientGatewayUpdateAttributesUpdatesItem struct 
 	// VLAN to be updated for this gateway.
 	Vlan *int64 `json:"vlan,omitempty"`
 }
+
 func (*GatewayChangeRequestGatewayClientGatewayUpdateAttributesUpdatesItem) isaGatewayChangeRequestGatewayClientGatewayUpdateAttributesUpdatesItem() bool {
 	return true
 }
@@ -5906,6 +5911,7 @@ type GatewayChangeRequestUpdatesItem struct {
 	// VLAN to be updated for this gateway.
 	Vlan *int64 `json:"vlan,omitempty"`
 }
+
 func (*GatewayChangeRequestUpdatesItem) isaGatewayChangeRequestUpdatesItem() bool {
 	return true
 }
@@ -6115,10 +6121,10 @@ type GatewayCollectionGatewaysItem struct {
 // Gateway BGP status. The list of enumerated values for this property may expand in the future. Code and processes
 // using this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItem_BgpStatus_Active = "active"
-	GatewayCollectionGatewaysItem_BgpStatus_Connect = "connect"
+	GatewayCollectionGatewaysItem_BgpStatus_Active      = "active"
+	GatewayCollectionGatewaysItem_BgpStatus_Connect     = "connect"
 	GatewayCollectionGatewaysItem_BgpStatus_Established = "established"
-	GatewayCollectionGatewaysItem_BgpStatus_Idle = "idle"
+	GatewayCollectionGatewaysItem_BgpStatus_Idle        = "idle"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItem.ConnectionMode property.
@@ -6126,21 +6132,21 @@ const (
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItem_ConnectionMode_Direct = "direct"
+	GatewayCollectionGatewaysItem_ConnectionMode_Direct  = "direct"
 	GatewayCollectionGatewaysItem_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItem.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayCollectionGatewaysItem_DefaultExportRouteFilter_Deny = "deny"
+	GatewayCollectionGatewaysItem_DefaultExportRouteFilter_Deny   = "deny"
 	GatewayCollectionGatewaysItem_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItem.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayCollectionGatewaysItem_DefaultImportRouteFilter_Deny = "deny"
+	GatewayCollectionGatewaysItem_DefaultImportRouteFilter_Deny   = "deny"
 	GatewayCollectionGatewaysItem_DefaultImportRouteFilter_Permit = "permit"
 )
 
@@ -6149,7 +6155,7 @@ const (
 // expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
 	GatewayCollectionGatewaysItem_LinkStatus_Down = "down"
-	GatewayCollectionGatewaysItem_LinkStatus_Up = "up"
+	GatewayCollectionGatewaysItem_LinkStatus_Up   = "up"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItem.MacsecCapability property.
@@ -6163,9 +6169,9 @@ const (
 // - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 // direct link creation.
 const (
-	GatewayCollectionGatewaysItem_MacsecCapability_Macsec = "macsec"
+	GatewayCollectionGatewaysItem_MacsecCapability_Macsec         = "macsec"
 	GatewayCollectionGatewaysItem_MacsecCapability_MacsecOptional = "macsec_optional"
-	GatewayCollectionGatewaysItem_MacsecCapability_NonMacsec = "non_macsec"
+	GatewayCollectionGatewaysItem_MacsecCapability_NonMacsec      = "non_macsec"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItem.OperationalStatus property.
@@ -6175,28 +6181,29 @@ const (
 // See `operational_status_reasons[]` for possible remediation of the `failed` `operational_status`.
 const (
 	GatewayCollectionGatewaysItem_OperationalStatus_AwaitingCompletionNotice = "awaiting_completion_notice"
-	GatewayCollectionGatewaysItem_OperationalStatus_AwaitingLoa = "awaiting_loa"
+	GatewayCollectionGatewaysItem_OperationalStatus_AwaitingLoa              = "awaiting_loa"
 	GatewayCollectionGatewaysItem_OperationalStatus_CompletionNoticeApproved = "completion_notice_approved"
 	GatewayCollectionGatewaysItem_OperationalStatus_CompletionNoticeReceived = "completion_notice_received"
 	GatewayCollectionGatewaysItem_OperationalStatus_CompletionNoticeRejected = "completion_notice_rejected"
-	GatewayCollectionGatewaysItem_OperationalStatus_Configuring = "configuring"
-	GatewayCollectionGatewaysItem_OperationalStatus_CreatePending = "create_pending"
-	GatewayCollectionGatewaysItem_OperationalStatus_CreateRejected = "create_rejected"
-	GatewayCollectionGatewaysItem_OperationalStatus_DeletePending = "delete_pending"
-	GatewayCollectionGatewaysItem_OperationalStatus_Failed = "failed"
-	GatewayCollectionGatewaysItem_OperationalStatus_LoaAccepted = "loa_accepted"
-	GatewayCollectionGatewaysItem_OperationalStatus_LoaCreated = "loa_created"
-	GatewayCollectionGatewaysItem_OperationalStatus_LoaRejected = "loa_rejected"
-	GatewayCollectionGatewaysItem_OperationalStatus_Provisioned = "provisioned"
+	GatewayCollectionGatewaysItem_OperationalStatus_Configuring              = "configuring"
+	GatewayCollectionGatewaysItem_OperationalStatus_CreatePending            = "create_pending"
+	GatewayCollectionGatewaysItem_OperationalStatus_CreateRejected           = "create_rejected"
+	GatewayCollectionGatewaysItem_OperationalStatus_DeletePending            = "delete_pending"
+	GatewayCollectionGatewaysItem_OperationalStatus_Failed                   = "failed"
+	GatewayCollectionGatewaysItem_OperationalStatus_LoaAccepted              = "loa_accepted"
+	GatewayCollectionGatewaysItem_OperationalStatus_LoaCreated               = "loa_created"
+	GatewayCollectionGatewaysItem_OperationalStatus_LoaRejected              = "loa_rejected"
+	GatewayCollectionGatewaysItem_OperationalStatus_Provisioned              = "provisioned"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItem.Type property.
 // Offering type. The list of enumerated values for this property may expand in the future. Code and processes using
 // this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItem_Type_Connect = "connect"
+	GatewayCollectionGatewaysItem_Type_Connect   = "connect"
 	GatewayCollectionGatewaysItem_Type_Dedicated = "dedicated"
 )
+
 func (*GatewayCollectionGatewaysItem) isaGatewayCollectionGatewaysItem() bool {
 	return true
 }
@@ -6481,7 +6488,7 @@ const (
 // - `should_secure` - Packets without MACsec headers are allowed. Use this policy to prefer network availability over
 // security.
 const (
-	GatewayMacsec_SecurityPolicy_MustSecure = "must_secure"
+	GatewayMacsec_SecurityPolicy_MustSecure   = "must_secure"
 	GatewayMacsec_SecurityPolicy_ShouldSecure = "should_secure"
 )
 
@@ -6496,11 +6503,11 @@ const (
 // See `status_reasons[]` for possible remediation of the `failed` `status`.
 const (
 	GatewayMacsec_Status_Deleting = "deleting"
-	GatewayMacsec_Status_Failed = "failed"
-	GatewayMacsec_Status_Init = "init"
-	GatewayMacsec_Status_Offline = "offline"
-	GatewayMacsec_Status_Pending = "pending"
-	GatewayMacsec_Status_Secured = "secured"
+	GatewayMacsec_Status_Failed   = "failed"
+	GatewayMacsec_Status_Init     = "init"
+	GatewayMacsec_Status_Offline  = "offline"
+	GatewayMacsec_Status_Pending  = "pending"
+	GatewayMacsec_Status_Secured  = "secured"
 )
 
 // UnmarshalGatewayMacsec unmarshals an instance of GatewayMacsec from the specified map of raw messages.
@@ -6640,7 +6647,7 @@ type GatewayMacsecCak struct {
 // There must be a `primary` session CAK. A `fallback` CAK is optional.
 const (
 	GatewayMacsecCak_Session_Fallback = "fallback"
-	GatewayMacsecCak_Session_Primary = "primary"
+	GatewayMacsecCak_Session_Primary  = "primary"
 )
 
 // Constants associated with the GatewayMacsecCak.Status property.
@@ -6665,11 +6672,11 @@ const (
 // key, then patch this CAK with the same or new key. Alternatively, you can delete this CAK if used for the `fallback`
 // session.
 const (
-	GatewayMacsecCak_Status_Active = "active"
-	GatewayMacsecCak_Status_Failed = "failed"
-	GatewayMacsecCak_Status_Inactive = "inactive"
+	GatewayMacsecCak_Status_Active      = "active"
+	GatewayMacsecCak_Status_Failed      = "failed"
+	GatewayMacsecCak_Status_Inactive    = "inactive"
 	GatewayMacsecCak_Status_Operational = "operational"
-	GatewayMacsecCak_Status_Rotating = "rotating"
+	GatewayMacsecCak_Status_Rotating    = "rotating"
 )
 
 // UnmarshalGatewayMacsecCak unmarshals an instance of GatewayMacsecCak from the specified map of raw messages.
@@ -6782,11 +6789,11 @@ type GatewayMacsecCakActiveDelta struct {
 // key, then patch this CAK with the same or new key. Alternatively, you can delete this CAK if used for the `fallback`
 // session.
 const (
-	GatewayMacsecCakActiveDelta_Status_Active = "active"
-	GatewayMacsecCakActiveDelta_Status_Failed = "failed"
-	GatewayMacsecCakActiveDelta_Status_Inactive = "inactive"
+	GatewayMacsecCakActiveDelta_Status_Active      = "active"
+	GatewayMacsecCakActiveDelta_Status_Failed      = "failed"
+	GatewayMacsecCakActiveDelta_Status_Inactive    = "inactive"
 	GatewayMacsecCakActiveDelta_Status_Operational = "operational"
-	GatewayMacsecCakActiveDelta_Status_Rotating = "rotating"
+	GatewayMacsecCakActiveDelta_Status_Rotating    = "rotating"
 )
 
 // UnmarshalGatewayMacsecCakActiveDelta unmarshals an instance of GatewayMacsecCakActiveDelta from the specified map of raw messages.
@@ -6837,6 +6844,7 @@ type GatewayMacsecCakKeyReference struct {
 	// The CRN of the referenced key.
 	Crn *string `json:"crn,omitempty"`
 }
+
 func (*GatewayMacsecCakKeyReference) isaGatewayMacsecCakKeyReference() bool {
 	return true
 }
@@ -6942,14 +6950,14 @@ type GatewayMacsecCakPrototype struct {
 // There must be a `primary` session CAK. A `fallback` CAK is optional.
 const (
 	GatewayMacsecCakPrototype_Session_Fallback = "fallback"
-	GatewayMacsecCakPrototype_Session_Primary = "primary"
+	GatewayMacsecCakPrototype_Session_Primary  = "primary"
 )
 
 // NewGatewayMacsecCakPrototype : Instantiate GatewayMacsecCakPrototype (Generic Model Constructor)
 func (*DirectLinkV1) NewGatewayMacsecCakPrototype(key GatewayMacsecCakKeyReferenceIntf, name string, session string) (_model *GatewayMacsecCakPrototype, err error) {
 	_model = &GatewayMacsecCakPrototype{
-		Key: key,
-		Name: core.StringPtr(name),
+		Key:     key,
+		Name:    core.StringPtr(name),
 		Session: core.StringPtr(session),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -7012,7 +7020,7 @@ type GatewayMacsecPatch struct {
 // - `should_secure` - Packets without MACsec headers are allowed. Use this policy to prefer network availability over
 // security.
 const (
-	GatewayMacsecPatch_SecurityPolicy_MustSecure = "must_secure"
+	GatewayMacsecPatch_SecurityPolicy_MustSecure   = "must_secure"
 	GatewayMacsecPatch_SecurityPolicy_ShouldSecure = "should_secure"
 )
 
@@ -7101,16 +7109,16 @@ type GatewayMacsecPrototype struct {
 // - `should_secure` - Packets without MACsec headers are allowed. Use this policy to prefer network availability over
 // security.
 const (
-	GatewayMacsecPrototype_SecurityPolicy_MustSecure = "must_secure"
+	GatewayMacsecPrototype_SecurityPolicy_MustSecure   = "must_secure"
 	GatewayMacsecPrototype_SecurityPolicy_ShouldSecure = "should_secure"
 )
 
 // NewGatewayMacsecPrototype : Instantiate GatewayMacsecPrototype (Generic Model Constructor)
 func (*DirectLinkV1) NewGatewayMacsecPrototype(active bool, caks []GatewayMacsecCakPrototype, sakRekey SakRekeyPrototypeIntf, securityPolicy string) (_model *GatewayMacsecPrototype, err error) {
 	_model = &GatewayMacsecPrototype{
-		Active: core.BoolPtr(active),
-		Caks: caks,
-		SakRekey: sakRekey,
+		Active:         core.BoolPtr(active),
+		Caks:           caks,
+		SakRekey:       sakRekey,
 		SecurityPolicy: core.StringPtr(securityPolicy),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -7187,7 +7195,7 @@ type GatewayMacsecReference struct {
 // - `should_secure` - Packets without MACsec headers are allowed. Use this policy to prefer network availability over
 // security.
 const (
-	GatewayMacsecReference_SecurityPolicy_MustSecure = "must_secure"
+	GatewayMacsecReference_SecurityPolicy_MustSecure   = "must_secure"
 	GatewayMacsecReference_SecurityPolicy_ShouldSecure = "should_secure"
 )
 
@@ -7202,11 +7210,11 @@ const (
 // See `status_reasons[]` for possible remediation of the `failed` `status`.
 const (
 	GatewayMacsecReference_Status_Deleting = "deleting"
-	GatewayMacsecReference_Status_Failed = "failed"
-	GatewayMacsecReference_Status_Init = "init"
-	GatewayMacsecReference_Status_Offline = "offline"
-	GatewayMacsecReference_Status_Pending = "pending"
-	GatewayMacsecReference_Status_Secured = "secured"
+	GatewayMacsecReference_Status_Failed   = "failed"
+	GatewayMacsecReference_Status_Init     = "init"
+	GatewayMacsecReference_Status_Offline  = "offline"
+	GatewayMacsecReference_Status_Pending  = "pending"
+	GatewayMacsecReference_Status_Secured  = "secured"
 )
 
 // UnmarshalGatewayMacsecReference unmarshals an instance of GatewayMacsecReference from the specified map of raw messages.
@@ -7367,21 +7375,21 @@ type GatewayPatchTemplate struct {
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GatewayPatchTemplate_ConnectionMode_Direct = "direct"
+	GatewayPatchTemplate_ConnectionMode_Direct  = "direct"
 	GatewayPatchTemplate_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GatewayPatchTemplate.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayPatchTemplate_DefaultExportRouteFilter_Deny = "deny"
+	GatewayPatchTemplate_DefaultExportRouteFilter_Deny   = "deny"
 	GatewayPatchTemplate_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayPatchTemplate.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayPatchTemplate_DefaultImportRouteFilter_Deny = "deny"
+	GatewayPatchTemplate_DefaultImportRouteFilter_Deny   = "deny"
 	GatewayPatchTemplate_DefaultImportRouteFilter_Permit = "permit"
 )
 
@@ -7602,10 +7610,10 @@ type GatewayStatistic struct {
 // Constants associated with the GatewayStatistic.Type property.
 // statistic type.
 const (
-	GatewayStatistic_Type_BfdSession = "bfd_session"
-	GatewayStatistic_Type_MacsecMkaSession = "macsec_mka_session"
+	GatewayStatistic_Type_BfdSession          = "bfd_session"
+	GatewayStatistic_Type_MacsecMkaSession    = "macsec_mka_session"
 	GatewayStatistic_Type_MacsecMkaStatistics = "macsec_mka_statistics"
-	GatewayStatistic_Type_MacsecPolicy = "macsec_policy"
+	GatewayStatistic_Type_MacsecPolicy        = "macsec_policy"
 )
 
 // UnmarshalGatewayStatistic unmarshals an instance of GatewayStatistic from the specified map of raw messages.
@@ -7673,11 +7681,12 @@ const (
 // Constants associated with the GatewayStatus.Value property.
 // Status.
 const (
-	GatewayStatus_Value_Active = "active"
-	GatewayStatus_Value_Connect = "connect"
+	GatewayStatus_Value_Active      = "active"
+	GatewayStatus_Value_Connect     = "connect"
 	GatewayStatus_Value_Established = "established"
-	GatewayStatus_Value_Idle = "idle"
+	GatewayStatus_Value_Idle        = "idle"
 )
+
 func (*GatewayStatus) isaGatewayStatus() bool {
 	return true
 }
@@ -7901,28 +7910,28 @@ type GatewayTemplate struct {
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GatewayTemplate_ConnectionMode_Direct = "direct"
+	GatewayTemplate_ConnectionMode_Direct  = "direct"
 	GatewayTemplate_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GatewayTemplate.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayTemplate_DefaultExportRouteFilter_Deny = "deny"
+	GatewayTemplate_DefaultExportRouteFilter_Deny   = "deny"
 	GatewayTemplate_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayTemplate.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayTemplate_DefaultImportRouteFilter_Deny = "deny"
+	GatewayTemplate_DefaultImportRouteFilter_Deny   = "deny"
 	GatewayTemplate_DefaultImportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayTemplate.Type property.
 // Offering type.
 const (
-	GatewayTemplate_Type_Connect = "connect"
+	GatewayTemplate_Type_Connect   = "connect"
 	GatewayTemplate_Type_Dedicated = "dedicated"
 )
 
@@ -7938,16 +7947,17 @@ const (
 // If not explicitly provided, the field will be assigned with the following priorities based on `cross_connect_router`
 // capabilities and available ports:
 //   - `macsec` was not provided in the request
-//     - `non_macsec`
-//     - `macsec_optional`
+//   - `non_macsec`
+//   - `macsec_optional`
 //   - `macsec` was provided in the request
-//     - `macsec_optional`
-//     - `macsec`.
+//   - `macsec_optional`
+//   - `macsec`.
 const (
-	GatewayTemplate_MacsecCapability_Macsec = "macsec"
+	GatewayTemplate_MacsecCapability_Macsec         = "macsec"
 	GatewayTemplate_MacsecCapability_MacsecOptional = "macsec_optional"
-	GatewayTemplate_MacsecCapability_NonMacsec = "non_macsec"
+	GatewayTemplate_MacsecCapability_NonMacsec      = "non_macsec"
 )
+
 func (*GatewayTemplate) isaGatewayTemplate() bool {
 	return true
 }
@@ -8116,7 +8126,7 @@ type GatewayTemplateRouteFilter struct {
 // Constants associated with the GatewayTemplateRouteFilter.Action property.
 // Determines whether routes that match the prefix-set will be allowed (permit) or rejected (deny) through the filter.
 const (
-	GatewayTemplateRouteFilter_Action_Deny = "deny"
+	GatewayTemplateRouteFilter_Action_Deny   = "deny"
 	GatewayTemplateRouteFilter_Action_Permit = "permit"
 )
 
@@ -8199,14 +8209,14 @@ type GatewayVirtualConnection struct {
 // The list of enumerated values for this property may expand in the future. Code and processes using this field  must
 // tolerate unexpected values.
 const (
-	GatewayVirtualConnection_Status_ApprovalPending = "approval_pending"
-	GatewayVirtualConnection_Status_Attached = "attached"
-	GatewayVirtualConnection_Status_Deleting = "deleting"
-	GatewayVirtualConnection_Status_DetachedByNetwork = "detached_by_network"
+	GatewayVirtualConnection_Status_ApprovalPending          = "approval_pending"
+	GatewayVirtualConnection_Status_Attached                 = "attached"
+	GatewayVirtualConnection_Status_Deleting                 = "deleting"
+	GatewayVirtualConnection_Status_DetachedByNetwork        = "detached_by_network"
 	GatewayVirtualConnection_Status_DetachedByNetworkPending = "detached_by_network_pending"
-	GatewayVirtualConnection_Status_Expired = "expired"
-	GatewayVirtualConnection_Status_Pending = "pending"
-	GatewayVirtualConnection_Status_Rejected = "rejected"
+	GatewayVirtualConnection_Status_Expired                  = "expired"
+	GatewayVirtualConnection_Status_Pending                  = "pending"
+	GatewayVirtualConnection_Status_Rejected                 = "rejected"
 )
 
 // Constants associated with the GatewayVirtualConnection.Type property.
@@ -8217,7 +8227,7 @@ const (
 const (
 	GatewayVirtualConnection_Type_Classic = "classic"
 	GatewayVirtualConnection_Type_Transit = "transit"
-	GatewayVirtualConnection_Type_Vpc = "vpc"
+	GatewayVirtualConnection_Type_Vpc     = "vpc"
 )
 
 // UnmarshalGatewayVirtualConnection unmarshals an instance of GatewayVirtualConnection from the specified map of raw messages.
@@ -8347,7 +8357,7 @@ type GetGatewayExportRouteFilterOptions struct {
 func (*DirectLinkV1) NewGetGatewayExportRouteFilterOptions(gatewayID string, id string) *GetGatewayExportRouteFilterOptions {
 	return &GetGatewayExportRouteFilterOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID: core.StringPtr(id),
+		ID:        core.StringPtr(id),
 	}
 }
 
@@ -8385,7 +8395,7 @@ type GetGatewayImportRouteFilterOptions struct {
 func (*DirectLinkV1) NewGetGatewayImportRouteFilterOptions(gatewayID string, id string) *GetGatewayImportRouteFilterOptions {
 	return &GetGatewayImportRouteFilterOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID: core.StringPtr(id),
+		ID:        core.StringPtr(id),
 	}
 }
 
@@ -8422,7 +8432,7 @@ type GetGatewayMacsecCakOptions struct {
 // NewGetGatewayMacsecCakOptions : Instantiate GetGatewayMacsecCakOptions
 func (*DirectLinkV1) NewGetGatewayMacsecCakOptions(id string, cakID string) *GetGatewayMacsecCakOptions {
 	return &GetGatewayMacsecCakOptions{
-		ID: core.StringPtr(id),
+		ID:    core.StringPtr(id),
 		CakID: core.StringPtr(cakID),
 	}
 }
@@ -8652,10 +8662,10 @@ type GetGatewayResponse struct {
 // Gateway BGP status. The list of enumerated values for this property may expand in the future. Code and processes
 // using this field  must tolerate unexpected values.
 const (
-	GetGatewayResponse_BgpStatus_Active = "active"
-	GetGatewayResponse_BgpStatus_Connect = "connect"
+	GetGatewayResponse_BgpStatus_Active      = "active"
+	GetGatewayResponse_BgpStatus_Connect     = "connect"
 	GetGatewayResponse_BgpStatus_Established = "established"
-	GetGatewayResponse_BgpStatus_Idle = "idle"
+	GetGatewayResponse_BgpStatus_Idle        = "idle"
 )
 
 // Constants associated with the GetGatewayResponse.ConnectionMode property.
@@ -8663,21 +8673,21 @@ const (
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GetGatewayResponse_ConnectionMode_Direct = "direct"
+	GetGatewayResponse_ConnectionMode_Direct  = "direct"
 	GetGatewayResponse_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GetGatewayResponse.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GetGatewayResponse_DefaultExportRouteFilter_Deny = "deny"
+	GetGatewayResponse_DefaultExportRouteFilter_Deny   = "deny"
 	GetGatewayResponse_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GetGatewayResponse.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GetGatewayResponse_DefaultImportRouteFilter_Deny = "deny"
+	GetGatewayResponse_DefaultImportRouteFilter_Deny   = "deny"
 	GetGatewayResponse_DefaultImportRouteFilter_Permit = "permit"
 )
 
@@ -8686,7 +8696,7 @@ const (
 // expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
 	GetGatewayResponse_LinkStatus_Down = "down"
-	GetGatewayResponse_LinkStatus_Up = "up"
+	GetGatewayResponse_LinkStatus_Up   = "up"
 )
 
 // Constants associated with the GetGatewayResponse.MacsecCapability property.
@@ -8700,9 +8710,9 @@ const (
 // - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 // direct link creation.
 const (
-	GetGatewayResponse_MacsecCapability_Macsec = "macsec"
+	GetGatewayResponse_MacsecCapability_Macsec         = "macsec"
 	GetGatewayResponse_MacsecCapability_MacsecOptional = "macsec_optional"
-	GetGatewayResponse_MacsecCapability_NonMacsec = "non_macsec"
+	GetGatewayResponse_MacsecCapability_NonMacsec      = "non_macsec"
 )
 
 // Constants associated with the GetGatewayResponse.OperationalStatus property.
@@ -8712,28 +8722,29 @@ const (
 // See `operational_status_reasons[]` for possible remediation of the `failed` `operational_status`.
 const (
 	GetGatewayResponse_OperationalStatus_AwaitingCompletionNotice = "awaiting_completion_notice"
-	GetGatewayResponse_OperationalStatus_AwaitingLoa = "awaiting_loa"
+	GetGatewayResponse_OperationalStatus_AwaitingLoa              = "awaiting_loa"
 	GetGatewayResponse_OperationalStatus_CompletionNoticeApproved = "completion_notice_approved"
 	GetGatewayResponse_OperationalStatus_CompletionNoticeReceived = "completion_notice_received"
 	GetGatewayResponse_OperationalStatus_CompletionNoticeRejected = "completion_notice_rejected"
-	GetGatewayResponse_OperationalStatus_Configuring = "configuring"
-	GetGatewayResponse_OperationalStatus_CreatePending = "create_pending"
-	GetGatewayResponse_OperationalStatus_CreateRejected = "create_rejected"
-	GetGatewayResponse_OperationalStatus_DeletePending = "delete_pending"
-	GetGatewayResponse_OperationalStatus_Failed = "failed"
-	GetGatewayResponse_OperationalStatus_LoaAccepted = "loa_accepted"
-	GetGatewayResponse_OperationalStatus_LoaCreated = "loa_created"
-	GetGatewayResponse_OperationalStatus_LoaRejected = "loa_rejected"
-	GetGatewayResponse_OperationalStatus_Provisioned = "provisioned"
+	GetGatewayResponse_OperationalStatus_Configuring              = "configuring"
+	GetGatewayResponse_OperationalStatus_CreatePending            = "create_pending"
+	GetGatewayResponse_OperationalStatus_CreateRejected           = "create_rejected"
+	GetGatewayResponse_OperationalStatus_DeletePending            = "delete_pending"
+	GetGatewayResponse_OperationalStatus_Failed                   = "failed"
+	GetGatewayResponse_OperationalStatus_LoaAccepted              = "loa_accepted"
+	GetGatewayResponse_OperationalStatus_LoaCreated               = "loa_created"
+	GetGatewayResponse_OperationalStatus_LoaRejected              = "loa_rejected"
+	GetGatewayResponse_OperationalStatus_Provisioned              = "provisioned"
 )
 
 // Constants associated with the GetGatewayResponse.Type property.
 // Offering type. The list of enumerated values for this property may expand in the future. Code and processes using
 // this field  must tolerate unexpected values.
 const (
-	GetGatewayResponse_Type_Connect = "connect"
+	GetGatewayResponse_Type_Connect   = "connect"
 	GetGatewayResponse_Type_Dedicated = "dedicated"
 )
+
 func (*GetGatewayResponse) isaGetGatewayResponse() bool {
 	return true
 }
@@ -8965,7 +8976,7 @@ type GetGatewayRouteReportOptions struct {
 func (*DirectLinkV1) NewGetGatewayRouteReportOptions(gatewayID string, id string) *GetGatewayRouteReportOptions {
 	return &GetGatewayRouteReportOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID: core.StringPtr(id),
+		ID:        core.StringPtr(id),
 	}
 }
 
@@ -9002,16 +9013,16 @@ type GetGatewayStatisticsOptions struct {
 // Constants associated with the GetGatewayStatisticsOptions.Type property.
 // Specify statistic to retrieve.
 const (
-	GetGatewayStatisticsOptions_Type_BfdSession = "bfd_session"
-	GetGatewayStatisticsOptions_Type_MacsecMkaSession = "macsec_mka_session"
+	GetGatewayStatisticsOptions_Type_BfdSession          = "bfd_session"
+	GetGatewayStatisticsOptions_Type_MacsecMkaSession    = "macsec_mka_session"
 	GetGatewayStatisticsOptions_Type_MacsecMkaStatistics = "macsec_mka_statistics"
-	GetGatewayStatisticsOptions_Type_MacsecPolicy = "macsec_policy"
+	GetGatewayStatisticsOptions_Type_MacsecPolicy        = "macsec_policy"
 )
 
 // NewGetGatewayStatisticsOptions : Instantiate GetGatewayStatisticsOptions
 func (*DirectLinkV1) NewGetGatewayStatisticsOptions(id string, typeVar string) *GetGatewayStatisticsOptions {
 	return &GetGatewayStatisticsOptions{
-		ID: core.StringPtr(id),
+		ID:   core.StringPtr(id),
 		Type: core.StringPtr(typeVar),
 	}
 }
@@ -9049,8 +9060,8 @@ type GetGatewayStatusOptions struct {
 // Constants associated with the GetGatewayStatusOptions.Type property.
 // Specify status to retrieve.
 const (
-	GetGatewayStatusOptions_Type_Bfd = "bfd"
-	GetGatewayStatusOptions_Type_Bgp = "bgp"
+	GetGatewayStatusOptions_Type_Bfd  = "bfd"
+	GetGatewayStatusOptions_Type_Bgp  = "bgp"
 	GetGatewayStatusOptions_Type_Link = "link"
 )
 
@@ -9095,7 +9106,7 @@ type GetGatewayVirtualConnectionOptions struct {
 func (*DirectLinkV1) NewGetGatewayVirtualConnectionOptions(gatewayID string, id string) *GetGatewayVirtualConnectionOptions {
 	return &GetGatewayVirtualConnectionOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID: core.StringPtr(id),
+		ID:        core.StringPtr(id),
 	}
 }
 
@@ -9420,7 +9431,7 @@ type ListOfferingTypeLocationCrossConnectRoutersOptions struct {
 // Constants associated with the ListOfferingTypeLocationCrossConnectRoutersOptions.OfferingType property.
 // The Direct Link offering type.  Current supported values are `"dedicated"` and `"connect"`.
 const (
-	ListOfferingTypeLocationCrossConnectRoutersOptions_OfferingType_Connect = "connect"
+	ListOfferingTypeLocationCrossConnectRoutersOptions_OfferingType_Connect   = "connect"
 	ListOfferingTypeLocationCrossConnectRoutersOptions_OfferingType_Dedicated = "dedicated"
 )
 
@@ -9462,7 +9473,7 @@ type ListOfferingTypeLocationsOptions struct {
 // Constants associated with the ListOfferingTypeLocationsOptions.OfferingType property.
 // The Direct Link offering type.  Current supported values are `"dedicated"` and `"connect"`.
 const (
-	ListOfferingTypeLocationsOptions_OfferingType_Connect = "connect"
+	ListOfferingTypeLocationsOptions_OfferingType_Connect   = "connect"
 	ListOfferingTypeLocationsOptions_OfferingType_Dedicated = "dedicated"
 )
 
@@ -9497,7 +9508,7 @@ type ListOfferingTypeSpeedsOptions struct {
 // Constants associated with the ListOfferingTypeSpeedsOptions.OfferingType property.
 // The Direct Link offering type.  Current supported values are `"dedicated"` and `"connect"`.
 const (
-	ListOfferingTypeSpeedsOptions_OfferingType_Connect = "connect"
+	ListOfferingTypeSpeedsOptions_OfferingType_Connect   = "connect"
 	ListOfferingTypeSpeedsOptions_OfferingType_Dedicated = "dedicated"
 )
 
@@ -9945,7 +9956,7 @@ type ReplaceGatewayAsPrependsOptions struct {
 func (*DirectLinkV1) NewReplaceGatewayAsPrependsOptions(gatewayID string, ifMatch string) *ReplaceGatewayAsPrependsOptions {
 	return &ReplaceGatewayAsPrependsOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		IfMatch: core.StringPtr(ifMatch),
+		IfMatch:   core.StringPtr(ifMatch),
 	}
 }
 
@@ -9993,7 +10004,7 @@ type ReplaceGatewayExportRouteFiltersOptions struct {
 func (*DirectLinkV1) NewReplaceGatewayExportRouteFiltersOptions(gatewayID string, ifMatch string) *ReplaceGatewayExportRouteFiltersOptions {
 	return &ReplaceGatewayExportRouteFiltersOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		IfMatch: core.StringPtr(ifMatch),
+		IfMatch:   core.StringPtr(ifMatch),
 	}
 }
 
@@ -10041,7 +10052,7 @@ type ReplaceGatewayImportRouteFiltersOptions struct {
 func (*DirectLinkV1) NewReplaceGatewayImportRouteFiltersOptions(gatewayID string, ifMatch string) *ReplaceGatewayImportRouteFiltersOptions {
 	return &ReplaceGatewayImportRouteFiltersOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		IfMatch: core.StringPtr(ifMatch),
+		IfMatch:   core.StringPtr(ifMatch),
 	}
 }
 
@@ -10156,7 +10167,7 @@ type RouteFilter struct {
 // Constants associated with the RouteFilter.Action property.
 // Determines whether routes that match the prefix-set will be allowed (permit) or rejected (deny) through the filter.
 const (
-	RouteFilter_Action_Deny = "deny"
+	RouteFilter_Action_Deny   = "deny"
 	RouteFilter_Action_Permit = "permit"
 )
 
@@ -10244,7 +10255,7 @@ type RouteReport struct {
 // using this field must tolerate unexpected values.
 const (
 	RouteReport_Status_Complete = "complete"
-	RouteReport_Status_Pending = "pending"
+	RouteReport_Status_Pending  = "pending"
 )
 
 // UnmarshalRouteReport unmarshals an instance of RouteReport from the specified map of raw messages.
@@ -10439,6 +10450,7 @@ type RouteReportOverlappingRoute struct {
 const (
 	RouteReportOverlappingRoute_Type_VirtualConnection = "virtual_connection"
 )
+
 func (*RouteReportOverlappingRoute) isaRouteReportOverlappingRoute() bool {
 	return true
 }
@@ -10556,6 +10568,7 @@ type SakRekey struct {
 const (
 	SakRekey_Mode_Timer = "timer"
 )
+
 func (*SakRekey) isaSakRekey() bool {
 	return true
 }
@@ -10598,6 +10611,7 @@ type SakRekeyPatch struct {
 const (
 	SakRekeyPatch_Mode_Timer = "timer"
 )
+
 func (*SakRekeyPatch) isaSakRekeyPatch() bool {
 	return true
 }
@@ -10654,6 +10668,7 @@ type SakRekeyPrototype struct {
 const (
 	SakRekeyPrototype_Mode_Timer = "timer"
 )
+
 func (*SakRekeyPrototype) isaSakRekeyPrototype() bool {
 	return true
 }
@@ -10729,17 +10744,17 @@ type SetGatewayMacsecOptions struct {
 // - `should_secure` - Packets without MACsec headers are allowed. Use this policy to prefer network availability over
 // security.
 const (
-	SetGatewayMacsecOptions_SecurityPolicy_MustSecure = "must_secure"
+	SetGatewayMacsecOptions_SecurityPolicy_MustSecure   = "must_secure"
 	SetGatewayMacsecOptions_SecurityPolicy_ShouldSecure = "should_secure"
 )
 
 // NewSetGatewayMacsecOptions : Instantiate SetGatewayMacsecOptions
 func (*DirectLinkV1) NewSetGatewayMacsecOptions(id string, active bool, caks []GatewayMacsecCakPrototype, sakRekey SakRekeyPrototypeIntf, securityPolicy string) *SetGatewayMacsecOptions {
 	return &SetGatewayMacsecOptions{
-		ID: core.StringPtr(id),
-		Active: core.BoolPtr(active),
-		Caks: caks,
-		SakRekey: sakRekey,
+		ID:             core.StringPtr(id),
+		Active:         core.BoolPtr(active),
+		Caks:           caks,
+		SakRekey:       sakRekey,
 		SecurityPolicy: core.StringPtr(securityPolicy),
 	}
 }
@@ -10838,8 +10853,8 @@ type UpdateGatewayExportRouteFilterOptions struct {
 // NewUpdateGatewayExportRouteFilterOptions : Instantiate UpdateGatewayExportRouteFilterOptions
 func (*DirectLinkV1) NewUpdateGatewayExportRouteFilterOptions(gatewayID string, id string, updateRouteFilterTemplatePatch map[string]interface{}) *UpdateGatewayExportRouteFilterOptions {
 	return &UpdateGatewayExportRouteFilterOptions{
-		GatewayID: core.StringPtr(gatewayID),
-		ID: core.StringPtr(id),
+		GatewayID:                      core.StringPtr(gatewayID),
+		ID:                             core.StringPtr(id),
 		UpdateRouteFilterTemplatePatch: updateRouteFilterTemplatePatch,
 	}
 }
@@ -10886,8 +10901,8 @@ type UpdateGatewayImportRouteFilterOptions struct {
 // NewUpdateGatewayImportRouteFilterOptions : Instantiate UpdateGatewayImportRouteFilterOptions
 func (*DirectLinkV1) NewUpdateGatewayImportRouteFilterOptions(gatewayID string, id string, updateRouteFilterTemplatePatch map[string]interface{}) *UpdateGatewayImportRouteFilterOptions {
 	return &UpdateGatewayImportRouteFilterOptions{
-		GatewayID: core.StringPtr(gatewayID),
-		ID: core.StringPtr(id),
+		GatewayID:                      core.StringPtr(gatewayID),
+		ID:                             core.StringPtr(id),
 		UpdateRouteFilterTemplatePatch: updateRouteFilterTemplatePatch,
 	}
 }
@@ -10934,8 +10949,8 @@ type UpdateGatewayMacsecCakOptions struct {
 // NewUpdateGatewayMacsecCakOptions : Instantiate UpdateGatewayMacsecCakOptions
 func (*DirectLinkV1) NewUpdateGatewayMacsecCakOptions(id string, cakID string, gatewayMacsecCakPatch map[string]interface{}) *UpdateGatewayMacsecCakOptions {
 	return &UpdateGatewayMacsecCakOptions{
-		ID: core.StringPtr(id),
-		CakID: core.StringPtr(cakID),
+		ID:                    core.StringPtr(id),
+		CakID:                 core.StringPtr(cakID),
 		GatewayMacsecCakPatch: gatewayMacsecCakPatch,
 	}
 }
@@ -10979,7 +10994,7 @@ type UpdateGatewayMacsecOptions struct {
 // NewUpdateGatewayMacsecOptions : Instantiate UpdateGatewayMacsecOptions
 func (*DirectLinkV1) NewUpdateGatewayMacsecOptions(id string, gatewayMacsecPatch map[string]interface{}) *UpdateGatewayMacsecOptions {
 	return &UpdateGatewayMacsecOptions{
-		ID: core.StringPtr(id),
+		ID:                 core.StringPtr(id),
 		GatewayMacsecPatch: gatewayMacsecPatch,
 	}
 }
@@ -11017,7 +11032,7 @@ type UpdateGatewayOptions struct {
 // NewUpdateGatewayOptions : Instantiate UpdateGatewayOptions
 func (*DirectLinkV1) NewUpdateGatewayOptions(id string, gatewayPatchTemplatePatch map[string]interface{}) *UpdateGatewayOptions {
 	return &UpdateGatewayOptions{
-		ID: core.StringPtr(id),
+		ID:                        core.StringPtr(id),
 		GatewayPatchTemplatePatch: gatewayPatchTemplatePatch,
 	}
 }
@@ -11059,7 +11074,7 @@ type UpdateGatewayVirtualConnectionOptions struct {
 func (*DirectLinkV1) NewUpdateGatewayVirtualConnectionOptions(gatewayID string, id string, gatewayVirtualConnectionPatchTemplatePatch map[string]interface{}) *UpdateGatewayVirtualConnectionOptions {
 	return &UpdateGatewayVirtualConnectionOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID: core.StringPtr(id),
+		ID:        core.StringPtr(id),
 		GatewayVirtualConnectionPatchTemplatePatch: gatewayVirtualConnectionPatchTemplatePatch,
 	}
 }
@@ -11121,7 +11136,7 @@ type UpdateRouteFilterTemplate struct {
 // Constants associated with the UpdateRouteFilterTemplate.Action property.
 // Determines whether routes that match the prefix-set will be allowed (permit) or rejected (deny) through the filter.
 const (
-	UpdateRouteFilterTemplate_Action_Deny = "deny"
+	UpdateRouteFilterTemplate_Action_Deny   = "deny"
 	UpdateRouteFilterTemplate_Action_Permit = "permit"
 )
 
@@ -11898,10 +11913,10 @@ type GatewayCollectionGatewaysItemCrossAccountGateway struct {
 // Gateway BGP status. The list of enumerated values for this property may expand in the future. Code and processes
 // using this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItemCrossAccountGateway_BgpStatus_Active = "active"
-	GatewayCollectionGatewaysItemCrossAccountGateway_BgpStatus_Connect = "connect"
+	GatewayCollectionGatewaysItemCrossAccountGateway_BgpStatus_Active      = "active"
+	GatewayCollectionGatewaysItemCrossAccountGateway_BgpStatus_Connect     = "connect"
 	GatewayCollectionGatewaysItemCrossAccountGateway_BgpStatus_Established = "established"
-	GatewayCollectionGatewaysItemCrossAccountGateway_BgpStatus_Idle = "idle"
+	GatewayCollectionGatewaysItemCrossAccountGateway_BgpStatus_Idle        = "idle"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemCrossAccountGateway.ConnectionMode property.
@@ -11909,7 +11924,7 @@ const (
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItemCrossAccountGateway_ConnectionMode_Direct = "direct"
+	GatewayCollectionGatewaysItemCrossAccountGateway_ConnectionMode_Direct  = "direct"
 	GatewayCollectionGatewaysItemCrossAccountGateway_ConnectionMode_Transit = "transit"
 )
 
@@ -11918,7 +11933,7 @@ const (
 // expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
 	GatewayCollectionGatewaysItemCrossAccountGateway_LinkStatus_Down = "down"
-	GatewayCollectionGatewaysItemCrossAccountGateway_LinkStatus_Up = "up"
+	GatewayCollectionGatewaysItemCrossAccountGateway_LinkStatus_Up   = "up"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemCrossAccountGateway.OperationalStatus property.
@@ -11926,25 +11941,25 @@ const (
 // processes using this field  must tolerate unexpected values.
 const (
 	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_AwaitingCompletionNotice = "awaiting_completion_notice"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_AwaitingLoa = "awaiting_loa"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_AwaitingLoa              = "awaiting_loa"
 	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_CompletionNoticeApproved = "completion_notice_approved"
 	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_CompletionNoticeReceived = "completion_notice_received"
 	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_CompletionNoticeRejected = "completion_notice_rejected"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_Configuring = "configuring"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_CreatePending = "create_pending"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_CreateRejected = "create_rejected"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_DeletePending = "delete_pending"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_LoaAccepted = "loa_accepted"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_LoaCreated = "loa_created"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_LoaRejected = "loa_rejected"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_Provisioned = "provisioned"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_Configuring              = "configuring"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_CreatePending            = "create_pending"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_CreateRejected           = "create_rejected"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_DeletePending            = "delete_pending"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_LoaAccepted              = "loa_accepted"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_LoaCreated               = "loa_created"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_LoaRejected              = "loa_rejected"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_Provisioned              = "provisioned"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemCrossAccountGateway.Type property.
 // Offering type. The list of enumerated values for this property may expand in the future. Code and processes using
 // this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItemCrossAccountGateway_Type_Connect = "connect"
+	GatewayCollectionGatewaysItemCrossAccountGateway_Type_Connect   = "connect"
 	GatewayCollectionGatewaysItemCrossAccountGateway_Type_Dedicated = "dedicated"
 )
 
@@ -12198,10 +12213,10 @@ type GatewayCollectionGatewaysItemGateway struct {
 // Gateway BGP status. The list of enumerated values for this property may expand in the future. Code and processes
 // using this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItemGateway_BgpStatus_Active = "active"
-	GatewayCollectionGatewaysItemGateway_BgpStatus_Connect = "connect"
+	GatewayCollectionGatewaysItemGateway_BgpStatus_Active      = "active"
+	GatewayCollectionGatewaysItemGateway_BgpStatus_Connect     = "connect"
 	GatewayCollectionGatewaysItemGateway_BgpStatus_Established = "established"
-	GatewayCollectionGatewaysItemGateway_BgpStatus_Idle = "idle"
+	GatewayCollectionGatewaysItemGateway_BgpStatus_Idle        = "idle"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemGateway.ConnectionMode property.
@@ -12209,21 +12224,21 @@ const (
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItemGateway_ConnectionMode_Direct = "direct"
+	GatewayCollectionGatewaysItemGateway_ConnectionMode_Direct  = "direct"
 	GatewayCollectionGatewaysItemGateway_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemGateway.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayCollectionGatewaysItemGateway_DefaultExportRouteFilter_Deny = "deny"
+	GatewayCollectionGatewaysItemGateway_DefaultExportRouteFilter_Deny   = "deny"
 	GatewayCollectionGatewaysItemGateway_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemGateway.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayCollectionGatewaysItemGateway_DefaultImportRouteFilter_Deny = "deny"
+	GatewayCollectionGatewaysItemGateway_DefaultImportRouteFilter_Deny   = "deny"
 	GatewayCollectionGatewaysItemGateway_DefaultImportRouteFilter_Permit = "permit"
 )
 
@@ -12232,7 +12247,7 @@ const (
 // expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
 	GatewayCollectionGatewaysItemGateway_LinkStatus_Down = "down"
-	GatewayCollectionGatewaysItemGateway_LinkStatus_Up = "up"
+	GatewayCollectionGatewaysItemGateway_LinkStatus_Up   = "up"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemGateway.MacsecCapability property.
@@ -12246,9 +12261,9 @@ const (
 // - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 // direct link creation.
 const (
-	GatewayCollectionGatewaysItemGateway_MacsecCapability_Macsec = "macsec"
+	GatewayCollectionGatewaysItemGateway_MacsecCapability_Macsec         = "macsec"
 	GatewayCollectionGatewaysItemGateway_MacsecCapability_MacsecOptional = "macsec_optional"
-	GatewayCollectionGatewaysItemGateway_MacsecCapability_NonMacsec = "non_macsec"
+	GatewayCollectionGatewaysItemGateway_MacsecCapability_NonMacsec      = "non_macsec"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemGateway.OperationalStatus property.
@@ -12258,26 +12273,26 @@ const (
 // See `operational_status_reasons[]` for possible remediation of the `failed` `operational_status`.
 const (
 	GatewayCollectionGatewaysItemGateway_OperationalStatus_AwaitingCompletionNotice = "awaiting_completion_notice"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_AwaitingLoa = "awaiting_loa"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_AwaitingLoa              = "awaiting_loa"
 	GatewayCollectionGatewaysItemGateway_OperationalStatus_CompletionNoticeApproved = "completion_notice_approved"
 	GatewayCollectionGatewaysItemGateway_OperationalStatus_CompletionNoticeReceived = "completion_notice_received"
 	GatewayCollectionGatewaysItemGateway_OperationalStatus_CompletionNoticeRejected = "completion_notice_rejected"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_Configuring = "configuring"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_CreatePending = "create_pending"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_CreateRejected = "create_rejected"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_DeletePending = "delete_pending"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_Failed = "failed"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_LoaAccepted = "loa_accepted"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_LoaCreated = "loa_created"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_LoaRejected = "loa_rejected"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_Provisioned = "provisioned"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_Configuring              = "configuring"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_CreatePending            = "create_pending"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_CreateRejected           = "create_rejected"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_DeletePending            = "delete_pending"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_Failed                   = "failed"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_LoaAccepted              = "loa_accepted"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_LoaCreated               = "loa_created"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_LoaRejected              = "loa_rejected"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_Provisioned              = "provisioned"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemGateway.Type property.
 // Offering type. The list of enumerated values for this property may expand in the future. Code and processes using
 // this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItemGateway_Type_Connect = "connect"
+	GatewayCollectionGatewaysItemGateway_Type_Connect   = "connect"
 	GatewayCollectionGatewaysItemGateway_Type_Dedicated = "dedicated"
 )
 
@@ -12606,10 +12621,10 @@ const (
 // Constants associated with the GatewayStatusGatewayBFDStatus.Value property.
 // Status.
 const (
-	GatewayStatusGatewayBFDStatus_Value_Down = "down"
-	GatewayStatusGatewayBFDStatus_Value_Init = "init"
+	GatewayStatusGatewayBFDStatus_Value_Down         = "down"
+	GatewayStatusGatewayBFDStatus_Value_Init         = "init"
 	GatewayStatusGatewayBFDStatus_Value_NotAvailable = "not_available"
-	GatewayStatusGatewayBFDStatus_Value_Up = "up"
+	GatewayStatusGatewayBFDStatus_Value_Up           = "up"
 )
 
 func (*GatewayStatusGatewayBFDStatus) isaGatewayStatus() bool {
@@ -12660,10 +12675,10 @@ const (
 // Constants associated with the GatewayStatusGatewayBGPStatus.Value property.
 // Status.
 const (
-	GatewayStatusGatewayBGPStatus_Value_Active = "active"
-	GatewayStatusGatewayBGPStatus_Value_Connect = "connect"
+	GatewayStatusGatewayBGPStatus_Value_Active      = "active"
+	GatewayStatusGatewayBGPStatus_Value_Connect     = "connect"
 	GatewayStatusGatewayBGPStatus_Value_Established = "established"
-	GatewayStatusGatewayBGPStatus_Value_Idle = "idle"
+	GatewayStatusGatewayBGPStatus_Value_Idle        = "idle"
 )
 
 func (*GatewayStatusGatewayBGPStatus) isaGatewayStatus() bool {
@@ -12715,7 +12730,7 @@ const (
 // Status.
 const (
 	GatewayStatusGatewayLinkStatus_Value_Down = "down"
-	GatewayStatusGatewayLinkStatus_Value_Up = "up"
+	GatewayStatusGatewayLinkStatus_Value_Up   = "up"
 )
 
 func (*GatewayStatusGatewayLinkStatus) isaGatewayStatus() bool {
@@ -12834,41 +12849,41 @@ type GatewayTemplateGatewayTypeConnectTemplate struct {
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GatewayTemplateGatewayTypeConnectTemplate_ConnectionMode_Direct = "direct"
+	GatewayTemplateGatewayTypeConnectTemplate_ConnectionMode_Direct  = "direct"
 	GatewayTemplateGatewayTypeConnectTemplate_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GatewayTemplateGatewayTypeConnectTemplate.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayTemplateGatewayTypeConnectTemplate_DefaultExportRouteFilter_Deny = "deny"
+	GatewayTemplateGatewayTypeConnectTemplate_DefaultExportRouteFilter_Deny   = "deny"
 	GatewayTemplateGatewayTypeConnectTemplate_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayTemplateGatewayTypeConnectTemplate.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayTemplateGatewayTypeConnectTemplate_DefaultImportRouteFilter_Deny = "deny"
+	GatewayTemplateGatewayTypeConnectTemplate_DefaultImportRouteFilter_Deny   = "deny"
 	GatewayTemplateGatewayTypeConnectTemplate_DefaultImportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayTemplateGatewayTypeConnectTemplate.Type property.
 // Offering type.
 const (
-	GatewayTemplateGatewayTypeConnectTemplate_Type_Connect = "connect"
+	GatewayTemplateGatewayTypeConnectTemplate_Type_Connect   = "connect"
 	GatewayTemplateGatewayTypeConnectTemplate_Type_Dedicated = "dedicated"
 )
 
 // NewGatewayTemplateGatewayTypeConnectTemplate : Instantiate GatewayTemplateGatewayTypeConnectTemplate (Generic Model Constructor)
 func (*DirectLinkV1) NewGatewayTemplateGatewayTypeConnectTemplate(bgpAsn int64, global bool, metered bool, name string, speedMbps int64, typeVar string, port *GatewayPortIdentity) (_model *GatewayTemplateGatewayTypeConnectTemplate, err error) {
 	_model = &GatewayTemplateGatewayTypeConnectTemplate{
-		BgpAsn: core.Int64Ptr(bgpAsn),
-		Global: core.BoolPtr(global),
-		Metered: core.BoolPtr(metered),
-		Name: core.StringPtr(name),
+		BgpAsn:    core.Int64Ptr(bgpAsn),
+		Global:    core.BoolPtr(global),
+		Metered:   core.BoolPtr(metered),
+		Name:      core.StringPtr(name),
 		SpeedMbps: core.Int64Ptr(speedMbps),
-		Type: core.StringPtr(typeVar),
-		Port: port,
+		Type:      core.StringPtr(typeVar),
+		Port:      port,
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	if err != nil {
@@ -13111,28 +13126,28 @@ type GatewayTemplateGatewayTypeDedicatedTemplate struct {
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GatewayTemplateGatewayTypeDedicatedTemplate_ConnectionMode_Direct = "direct"
+	GatewayTemplateGatewayTypeDedicatedTemplate_ConnectionMode_Direct  = "direct"
 	GatewayTemplateGatewayTypeDedicatedTemplate_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GatewayTemplateGatewayTypeDedicatedTemplate.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayTemplateGatewayTypeDedicatedTemplate_DefaultExportRouteFilter_Deny = "deny"
+	GatewayTemplateGatewayTypeDedicatedTemplate_DefaultExportRouteFilter_Deny   = "deny"
 	GatewayTemplateGatewayTypeDedicatedTemplate_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayTemplateGatewayTypeDedicatedTemplate.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayTemplateGatewayTypeDedicatedTemplate_DefaultImportRouteFilter_Deny = "deny"
+	GatewayTemplateGatewayTypeDedicatedTemplate_DefaultImportRouteFilter_Deny   = "deny"
 	GatewayTemplateGatewayTypeDedicatedTemplate_DefaultImportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayTemplateGatewayTypeDedicatedTemplate.Type property.
 // Offering type.
 const (
-	GatewayTemplateGatewayTypeDedicatedTemplate_Type_Connect = "connect"
+	GatewayTemplateGatewayTypeDedicatedTemplate_Type_Connect   = "connect"
 	GatewayTemplateGatewayTypeDedicatedTemplate_Type_Dedicated = "dedicated"
 )
 
@@ -13148,30 +13163,30 @@ const (
 // If not explicitly provided, the field will be assigned with the following priorities based on `cross_connect_router`
 // capabilities and available ports:
 //   - `macsec` was not provided in the request
-//     - `non_macsec`
-//     - `macsec_optional`
+//   - `non_macsec`
+//   - `macsec_optional`
 //   - `macsec` was provided in the request
-//     - `macsec_optional`
-//     - `macsec`.
+//   - `macsec_optional`
+//   - `macsec`.
 const (
-	GatewayTemplateGatewayTypeDedicatedTemplate_MacsecCapability_Macsec = "macsec"
+	GatewayTemplateGatewayTypeDedicatedTemplate_MacsecCapability_Macsec         = "macsec"
 	GatewayTemplateGatewayTypeDedicatedTemplate_MacsecCapability_MacsecOptional = "macsec_optional"
-	GatewayTemplateGatewayTypeDedicatedTemplate_MacsecCapability_NonMacsec = "non_macsec"
+	GatewayTemplateGatewayTypeDedicatedTemplate_MacsecCapability_NonMacsec      = "non_macsec"
 )
 
 // NewGatewayTemplateGatewayTypeDedicatedTemplate : Instantiate GatewayTemplateGatewayTypeDedicatedTemplate (Generic Model Constructor)
 func (*DirectLinkV1) NewGatewayTemplateGatewayTypeDedicatedTemplate(bgpAsn int64, global bool, metered bool, name string, speedMbps int64, typeVar string, carrierName string, crossConnectRouter string, customerName string, locationName string) (_model *GatewayTemplateGatewayTypeDedicatedTemplate, err error) {
 	_model = &GatewayTemplateGatewayTypeDedicatedTemplate{
-		BgpAsn: core.Int64Ptr(bgpAsn),
-		Global: core.BoolPtr(global),
-		Metered: core.BoolPtr(metered),
-		Name: core.StringPtr(name),
-		SpeedMbps: core.Int64Ptr(speedMbps),
-		Type: core.StringPtr(typeVar),
-		CarrierName: core.StringPtr(carrierName),
+		BgpAsn:             core.Int64Ptr(bgpAsn),
+		Global:             core.BoolPtr(global),
+		Metered:            core.BoolPtr(metered),
+		Name:               core.StringPtr(name),
+		SpeedMbps:          core.Int64Ptr(speedMbps),
+		Type:               core.StringPtr(typeVar),
+		CarrierName:        core.StringPtr(carrierName),
 		CrossConnectRouter: core.StringPtr(crossConnectRouter),
-		CustomerName: core.StringPtr(customerName),
-		LocationName: core.StringPtr(locationName),
+		CustomerName:       core.StringPtr(customerName),
+		LocationName:       core.StringPtr(locationName),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	if err != nil {
@@ -13389,10 +13404,10 @@ type GetGatewayResponseCrossAccountGateway struct {
 // Gateway BGP status. The list of enumerated values for this property may expand in the future. Code and processes
 // using this field  must tolerate unexpected values.
 const (
-	GetGatewayResponseCrossAccountGateway_BgpStatus_Active = "active"
-	GetGatewayResponseCrossAccountGateway_BgpStatus_Connect = "connect"
+	GetGatewayResponseCrossAccountGateway_BgpStatus_Active      = "active"
+	GetGatewayResponseCrossAccountGateway_BgpStatus_Connect     = "connect"
 	GetGatewayResponseCrossAccountGateway_BgpStatus_Established = "established"
-	GetGatewayResponseCrossAccountGateway_BgpStatus_Idle = "idle"
+	GetGatewayResponseCrossAccountGateway_BgpStatus_Idle        = "idle"
 )
 
 // Constants associated with the GetGatewayResponseCrossAccountGateway.ConnectionMode property.
@@ -13400,7 +13415,7 @@ const (
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GetGatewayResponseCrossAccountGateway_ConnectionMode_Direct = "direct"
+	GetGatewayResponseCrossAccountGateway_ConnectionMode_Direct  = "direct"
 	GetGatewayResponseCrossAccountGateway_ConnectionMode_Transit = "transit"
 )
 
@@ -13409,7 +13424,7 @@ const (
 // expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
 	GetGatewayResponseCrossAccountGateway_LinkStatus_Down = "down"
-	GetGatewayResponseCrossAccountGateway_LinkStatus_Up = "up"
+	GetGatewayResponseCrossAccountGateway_LinkStatus_Up   = "up"
 )
 
 // Constants associated with the GetGatewayResponseCrossAccountGateway.OperationalStatus property.
@@ -13417,25 +13432,25 @@ const (
 // processes using this field  must tolerate unexpected values.
 const (
 	GetGatewayResponseCrossAccountGateway_OperationalStatus_AwaitingCompletionNotice = "awaiting_completion_notice"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_AwaitingLoa = "awaiting_loa"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_AwaitingLoa              = "awaiting_loa"
 	GetGatewayResponseCrossAccountGateway_OperationalStatus_CompletionNoticeApproved = "completion_notice_approved"
 	GetGatewayResponseCrossAccountGateway_OperationalStatus_CompletionNoticeReceived = "completion_notice_received"
 	GetGatewayResponseCrossAccountGateway_OperationalStatus_CompletionNoticeRejected = "completion_notice_rejected"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_Configuring = "configuring"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_CreatePending = "create_pending"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_CreateRejected = "create_rejected"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_DeletePending = "delete_pending"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_LoaAccepted = "loa_accepted"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_LoaCreated = "loa_created"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_LoaRejected = "loa_rejected"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_Provisioned = "provisioned"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_Configuring              = "configuring"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_CreatePending            = "create_pending"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_CreateRejected           = "create_rejected"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_DeletePending            = "delete_pending"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_LoaAccepted              = "loa_accepted"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_LoaCreated               = "loa_created"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_LoaRejected              = "loa_rejected"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_Provisioned              = "provisioned"
 )
 
 // Constants associated with the GetGatewayResponseCrossAccountGateway.Type property.
 // Offering type. The list of enumerated values for this property may expand in the future. Code and processes using
 // this field  must tolerate unexpected values.
 const (
-	GetGatewayResponseCrossAccountGateway_Type_Connect = "connect"
+	GetGatewayResponseCrossAccountGateway_Type_Connect   = "connect"
 	GetGatewayResponseCrossAccountGateway_Type_Dedicated = "dedicated"
 )
 
@@ -13689,10 +13704,10 @@ type GetGatewayResponseGateway struct {
 // Gateway BGP status. The list of enumerated values for this property may expand in the future. Code and processes
 // using this field  must tolerate unexpected values.
 const (
-	GetGatewayResponseGateway_BgpStatus_Active = "active"
-	GetGatewayResponseGateway_BgpStatus_Connect = "connect"
+	GetGatewayResponseGateway_BgpStatus_Active      = "active"
+	GetGatewayResponseGateway_BgpStatus_Connect     = "connect"
 	GetGatewayResponseGateway_BgpStatus_Established = "established"
-	GetGatewayResponseGateway_BgpStatus_Idle = "idle"
+	GetGatewayResponseGateway_BgpStatus_Idle        = "idle"
 )
 
 // Constants associated with the GetGatewayResponseGateway.ConnectionMode property.
@@ -13700,21 +13715,21 @@ const (
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GetGatewayResponseGateway_ConnectionMode_Direct = "direct"
+	GetGatewayResponseGateway_ConnectionMode_Direct  = "direct"
 	GetGatewayResponseGateway_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GetGatewayResponseGateway.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GetGatewayResponseGateway_DefaultExportRouteFilter_Deny = "deny"
+	GetGatewayResponseGateway_DefaultExportRouteFilter_Deny   = "deny"
 	GetGatewayResponseGateway_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GetGatewayResponseGateway.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GetGatewayResponseGateway_DefaultImportRouteFilter_Deny = "deny"
+	GetGatewayResponseGateway_DefaultImportRouteFilter_Deny   = "deny"
 	GetGatewayResponseGateway_DefaultImportRouteFilter_Permit = "permit"
 )
 
@@ -13723,7 +13738,7 @@ const (
 // expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
 	GetGatewayResponseGateway_LinkStatus_Down = "down"
-	GetGatewayResponseGateway_LinkStatus_Up = "up"
+	GetGatewayResponseGateway_LinkStatus_Up   = "up"
 )
 
 // Constants associated with the GetGatewayResponseGateway.MacsecCapability property.
@@ -13737,9 +13752,9 @@ const (
 // - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 // direct link creation.
 const (
-	GetGatewayResponseGateway_MacsecCapability_Macsec = "macsec"
+	GetGatewayResponseGateway_MacsecCapability_Macsec         = "macsec"
 	GetGatewayResponseGateway_MacsecCapability_MacsecOptional = "macsec_optional"
-	GetGatewayResponseGateway_MacsecCapability_NonMacsec = "non_macsec"
+	GetGatewayResponseGateway_MacsecCapability_NonMacsec      = "non_macsec"
 )
 
 // Constants associated with the GetGatewayResponseGateway.OperationalStatus property.
@@ -13749,26 +13764,26 @@ const (
 // See `operational_status_reasons[]` for possible remediation of the `failed` `operational_status`.
 const (
 	GetGatewayResponseGateway_OperationalStatus_AwaitingCompletionNotice = "awaiting_completion_notice"
-	GetGatewayResponseGateway_OperationalStatus_AwaitingLoa = "awaiting_loa"
+	GetGatewayResponseGateway_OperationalStatus_AwaitingLoa              = "awaiting_loa"
 	GetGatewayResponseGateway_OperationalStatus_CompletionNoticeApproved = "completion_notice_approved"
 	GetGatewayResponseGateway_OperationalStatus_CompletionNoticeReceived = "completion_notice_received"
 	GetGatewayResponseGateway_OperationalStatus_CompletionNoticeRejected = "completion_notice_rejected"
-	GetGatewayResponseGateway_OperationalStatus_Configuring = "configuring"
-	GetGatewayResponseGateway_OperationalStatus_CreatePending = "create_pending"
-	GetGatewayResponseGateway_OperationalStatus_CreateRejected = "create_rejected"
-	GetGatewayResponseGateway_OperationalStatus_DeletePending = "delete_pending"
-	GetGatewayResponseGateway_OperationalStatus_Failed = "failed"
-	GetGatewayResponseGateway_OperationalStatus_LoaAccepted = "loa_accepted"
-	GetGatewayResponseGateway_OperationalStatus_LoaCreated = "loa_created"
-	GetGatewayResponseGateway_OperationalStatus_LoaRejected = "loa_rejected"
-	GetGatewayResponseGateway_OperationalStatus_Provisioned = "provisioned"
+	GetGatewayResponseGateway_OperationalStatus_Configuring              = "configuring"
+	GetGatewayResponseGateway_OperationalStatus_CreatePending            = "create_pending"
+	GetGatewayResponseGateway_OperationalStatus_CreateRejected           = "create_rejected"
+	GetGatewayResponseGateway_OperationalStatus_DeletePending            = "delete_pending"
+	GetGatewayResponseGateway_OperationalStatus_Failed                   = "failed"
+	GetGatewayResponseGateway_OperationalStatus_LoaAccepted              = "loa_accepted"
+	GetGatewayResponseGateway_OperationalStatus_LoaCreated               = "loa_created"
+	GetGatewayResponseGateway_OperationalStatus_LoaRejected              = "loa_rejected"
+	GetGatewayResponseGateway_OperationalStatus_Provisioned              = "provisioned"
 )
 
 // Constants associated with the GetGatewayResponseGateway.Type property.
 // Offering type. The list of enumerated values for this property may expand in the future. Code and processes using
 // this field  must tolerate unexpected values.
 const (
-	GetGatewayResponseGateway_Type_Connect = "connect"
+	GetGatewayResponseGateway_Type_Connect   = "connect"
 	GetGatewayResponseGateway_Type_Dedicated = "dedicated"
 )
 
@@ -14042,7 +14057,7 @@ type RouteReportOverlappingRouteForOthers struct {
 // type of the route.
 const (
 	RouteReportOverlappingRouteForOthers_Type_Gateway = "gateway"
-	RouteReportOverlappingRouteForOthers_Type_OnPrem = "on_prem"
+	RouteReportOverlappingRouteForOthers_Type_OnPrem  = "on_prem"
 )
 
 func (*RouteReportOverlappingRouteForOthers) isaRouteReportOverlappingRoute() bool {
@@ -14168,7 +14183,7 @@ const (
 func (*DirectLinkV1) NewSakRekeyPatchSakRekeyTimerModePatch(interval int64, mode string) (_model *SakRekeyPatchSakRekeyTimerModePatch, err error) {
 	_model = &SakRekeyPatchSakRekeyTimerModePatch{
 		Interval: core.Int64Ptr(interval),
-		Mode: core.StringPtr(mode),
+		Mode:     core.StringPtr(mode),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	if err != nil {
@@ -14273,7 +14288,7 @@ const (
 func (*DirectLinkV1) NewSakRekeyPrototypeSakRekeyTimerModePrototype(interval int64, mode string) (_model *SakRekeyPrototypeSakRekeyTimerModePrototype, err error) {
 	_model = &SakRekeyPrototypeSakRekeyTimerModePrototype{
 		Interval: core.Int64Ptr(interval),
-		Mode: core.StringPtr(mode),
+		Mode:     core.StringPtr(mode),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	if err != nil {
@@ -14340,13 +14355,11 @@ func UnmarshalSakRekeyTimerMode(m map[string]json.RawMessage, result interface{}
 	return
 }
 
-//
 // PortsPager can be used to simplify the use of the "ListPorts" method.
-//
 type PortsPager struct {
-	hasNext bool
-	options *ListPortsOptions
-	client  *DirectLinkV1
+	hasNext     bool
+	options     *ListPortsOptions
+	client      *DirectLinkV1
 	pageContext struct {
 		next *string
 	}

--- a/directlinkv1/direct_link_v1.go
+++ b/directlinkv1/direct_link_v1.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2024.
+ * (C) Copyright IBM Corp. 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.82.1-2082d402-20231115-195014
+ * IBM OpenAPI SDK Code Generator Version: 3.107.1-41b0fbd0-20250825-080732
  */
 
 // Package directlinkv1 : Operations and models for the DirectLinkV1 service
@@ -213,12 +213,12 @@ func (directLink *DirectLinkV1) ListGatewaysWithContext(ctx context.Context, lis
 		return
 	}
 
-	for headerName, headerValue := range listGatewaysOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGateways")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGateways")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range listGatewaysOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -280,12 +280,12 @@ func (directLink *DirectLinkV1) CreateGatewayWithContext(ctx context.Context, cr
 		return
 	}
 
-	for headerName, headerValue := range createGatewayOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGateway")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGateway")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range createGatewayOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -358,12 +358,12 @@ func (directLink *DirectLinkV1) DeleteGatewayWithContext(ctx context.Context, de
 		return
 	}
 
-	for headerName, headerValue := range deleteGatewayOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "DeleteGateway")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "DeleteGateway")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range deleteGatewayOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 
@@ -419,12 +419,12 @@ func (directLink *DirectLinkV1) GetGatewayWithContext(ctx context.Context, getGa
 		return
 	}
 
-	for headerName, headerValue := range getGatewayOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGateway")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGateway")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range getGatewayOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -490,12 +490,12 @@ func (directLink *DirectLinkV1) UpdateGatewayWithContext(ctx context.Context, up
 		return
 	}
 
-	for headerName, headerValue := range updateGatewayOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "UpdateGateway")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "UpdateGateway")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range updateGatewayOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -571,12 +571,12 @@ func (directLink *DirectLinkV1) CreateGatewayActionWithContext(ctx context.Conte
 		return
 	}
 
-	for headerName, headerValue := range createGatewayActionOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGatewayAction")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGatewayAction")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range createGatewayActionOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -689,12 +689,12 @@ func (directLink *DirectLinkV1) ListGatewayCompletionNoticeWithContext(ctx conte
 		return
 	}
 
-	for headerName, headerValue := range listGatewayCompletionNoticeOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayCompletionNotice")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayCompletionNotice")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range listGatewayCompletionNoticeOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/pdf")
@@ -737,7 +737,7 @@ func (directLink *DirectLinkV1) CreateGatewayCompletionNoticeWithContext(ctx con
 		err = core.SDKErrorf(err, "", "struct-validation-error", common.GetComponentInfo())
 		return
 	}
-	if createGatewayCompletionNoticeOptions.Upload == nil {
+	if (createGatewayCompletionNoticeOptions.Upload == nil) {
 		err = core.SDKErrorf(nil, "upload must be supplied", "condition-not-met", common.GetComponentInfo())
 		return
 	}
@@ -755,12 +755,12 @@ func (directLink *DirectLinkV1) CreateGatewayCompletionNoticeWithContext(ctx con
 		return
 	}
 
-	for headerName, headerValue := range createGatewayCompletionNoticeOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGatewayCompletionNotice")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGatewayCompletionNotice")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range createGatewayCompletionNoticeOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 
@@ -821,12 +821,12 @@ func (directLink *DirectLinkV1) ListGatewayLetterOfAuthorizationWithContext(ctx 
 		return
 	}
 
-	for headerName, headerValue := range listGatewayLetterOfAuthorizationOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayLetterOfAuthorization")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayLetterOfAuthorization")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range listGatewayLetterOfAuthorizationOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/pdf")
@@ -884,12 +884,12 @@ func (directLink *DirectLinkV1) GetGatewayStatisticsWithContext(ctx context.Cont
 		return
 	}
 
-	for headerName, headerValue := range getGatewayStatisticsOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayStatistics")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayStatistics")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range getGatewayStatisticsOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -956,12 +956,12 @@ func (directLink *DirectLinkV1) GetGatewayStatusWithContext(ctx context.Context,
 		return
 	}
 
-	for headerName, headerValue := range getGatewayStatusOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayStatus")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayStatus")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range getGatewayStatusOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -1030,12 +1030,12 @@ func (directLink *DirectLinkV1) ListGatewayAsPrependsWithContext(ctx context.Con
 		return
 	}
 
-	for headerName, headerValue := range listGatewayAsPrependsOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayAsPrepends")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayAsPrepends")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range listGatewayAsPrependsOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -1102,12 +1102,12 @@ func (directLink *DirectLinkV1) ReplaceGatewayAsPrependsWithContext(ctx context.
 		return
 	}
 
-	for headerName, headerValue := range replaceGatewayAsPrependsOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ReplaceGatewayAsPrepends")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ReplaceGatewayAsPrepends")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range replaceGatewayAsPrependsOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -1194,12 +1194,12 @@ func (directLink *DirectLinkV1) ListGatewayExportRouteFiltersWithContext(ctx con
 		return
 	}
 
-	for headerName, headerValue := range listGatewayExportRouteFiltersOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayExportRouteFilters")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayExportRouteFilters")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range listGatewayExportRouteFiltersOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -1275,12 +1275,12 @@ func (directLink *DirectLinkV1) CreateGatewayExportRouteFilterWithContext(ctx co
 		return
 	}
 
-	for headerName, headerValue := range createGatewayExportRouteFilterOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGatewayExportRouteFilter")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGatewayExportRouteFilter")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range createGatewayExportRouteFilterOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -1369,12 +1369,12 @@ func (directLink *DirectLinkV1) ReplaceGatewayExportRouteFiltersWithContext(ctx 
 		return
 	}
 
-	for headerName, headerValue := range replaceGatewayExportRouteFiltersOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ReplaceGatewayExportRouteFilters")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ReplaceGatewayExportRouteFilters")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range replaceGatewayExportRouteFiltersOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -1447,7 +1447,7 @@ func (directLink *DirectLinkV1) DeleteGatewayExportRouteFilterWithContext(ctx co
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *deleteGatewayExportRouteFilterOptions.GatewayID,
-		"id":         *deleteGatewayExportRouteFilterOptions.ID,
+		"id": *deleteGatewayExportRouteFilterOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
@@ -1459,12 +1459,12 @@ func (directLink *DirectLinkV1) DeleteGatewayExportRouteFilterWithContext(ctx co
 		return
 	}
 
-	for headerName, headerValue := range deleteGatewayExportRouteFilterOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "DeleteGatewayExportRouteFilter")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "DeleteGatewayExportRouteFilter")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range deleteGatewayExportRouteFilterOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 
@@ -1509,7 +1509,7 @@ func (directLink *DirectLinkV1) GetGatewayExportRouteFilterWithContext(ctx conte
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *getGatewayExportRouteFilterOptions.GatewayID,
-		"id":         *getGatewayExportRouteFilterOptions.ID,
+		"id": *getGatewayExportRouteFilterOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -1521,12 +1521,12 @@ func (directLink *DirectLinkV1) GetGatewayExportRouteFilterWithContext(ctx conte
 		return
 	}
 
-	for headerName, headerValue := range getGatewayExportRouteFilterOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayExportRouteFilter")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayExportRouteFilter")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range getGatewayExportRouteFilterOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -1589,7 +1589,7 @@ func (directLink *DirectLinkV1) UpdateGatewayExportRouteFilterWithContext(ctx co
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *updateGatewayExportRouteFilterOptions.GatewayID,
-		"id":         *updateGatewayExportRouteFilterOptions.ID,
+		"id": *updateGatewayExportRouteFilterOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.PATCH)
@@ -1601,12 +1601,12 @@ func (directLink *DirectLinkV1) UpdateGatewayExportRouteFilterWithContext(ctx co
 		return
 	}
 
-	for headerName, headerValue := range updateGatewayExportRouteFilterOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "UpdateGatewayExportRouteFilter")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "UpdateGatewayExportRouteFilter")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range updateGatewayExportRouteFilterOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -1685,12 +1685,12 @@ func (directLink *DirectLinkV1) ListGatewayImportRouteFiltersWithContext(ctx con
 		return
 	}
 
-	for headerName, headerValue := range listGatewayImportRouteFiltersOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayImportRouteFilters")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayImportRouteFilters")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range listGatewayImportRouteFiltersOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -1766,12 +1766,12 @@ func (directLink *DirectLinkV1) CreateGatewayImportRouteFilterWithContext(ctx co
 		return
 	}
 
-	for headerName, headerValue := range createGatewayImportRouteFilterOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGatewayImportRouteFilter")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGatewayImportRouteFilter")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range createGatewayImportRouteFilterOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -1860,12 +1860,12 @@ func (directLink *DirectLinkV1) ReplaceGatewayImportRouteFiltersWithContext(ctx 
 		return
 	}
 
-	for headerName, headerValue := range replaceGatewayImportRouteFiltersOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ReplaceGatewayImportRouteFilters")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ReplaceGatewayImportRouteFilters")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range replaceGatewayImportRouteFiltersOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -1938,7 +1938,7 @@ func (directLink *DirectLinkV1) DeleteGatewayImportRouteFilterWithContext(ctx co
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *deleteGatewayImportRouteFilterOptions.GatewayID,
-		"id":         *deleteGatewayImportRouteFilterOptions.ID,
+		"id": *deleteGatewayImportRouteFilterOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
@@ -1950,12 +1950,12 @@ func (directLink *DirectLinkV1) DeleteGatewayImportRouteFilterWithContext(ctx co
 		return
 	}
 
-	for headerName, headerValue := range deleteGatewayImportRouteFilterOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "DeleteGatewayImportRouteFilter")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "DeleteGatewayImportRouteFilter")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range deleteGatewayImportRouteFilterOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 
@@ -2000,7 +2000,7 @@ func (directLink *DirectLinkV1) GetGatewayImportRouteFilterWithContext(ctx conte
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *getGatewayImportRouteFilterOptions.GatewayID,
-		"id":         *getGatewayImportRouteFilterOptions.ID,
+		"id": *getGatewayImportRouteFilterOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -2012,12 +2012,12 @@ func (directLink *DirectLinkV1) GetGatewayImportRouteFilterWithContext(ctx conte
 		return
 	}
 
-	for headerName, headerValue := range getGatewayImportRouteFilterOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayImportRouteFilter")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayImportRouteFilter")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range getGatewayImportRouteFilterOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -2080,7 +2080,7 @@ func (directLink *DirectLinkV1) UpdateGatewayImportRouteFilterWithContext(ctx co
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *updateGatewayImportRouteFilterOptions.GatewayID,
-		"id":         *updateGatewayImportRouteFilterOptions.ID,
+		"id": *updateGatewayImportRouteFilterOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.PATCH)
@@ -2092,12 +2092,12 @@ func (directLink *DirectLinkV1) UpdateGatewayImportRouteFilterWithContext(ctx co
 		return
 	}
 
-	for headerName, headerValue := range updateGatewayImportRouteFilterOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "UpdateGatewayImportRouteFilter")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "UpdateGatewayImportRouteFilter")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range updateGatewayImportRouteFilterOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -2170,12 +2170,12 @@ func (directLink *DirectLinkV1) UnsetGatewayMacsecWithContext(ctx context.Contex
 		return
 	}
 
-	for headerName, headerValue := range unsetGatewayMacsecOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "UnsetGatewayMacsec")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "UnsetGatewayMacsec")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range unsetGatewayMacsecOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 
@@ -2231,12 +2231,12 @@ func (directLink *DirectLinkV1) GetGatewayMacsecWithContext(ctx context.Context,
 		return
 	}
 
-	for headerName, headerValue := range getGatewayMacsecOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayMacsec")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayMacsec")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range getGatewayMacsecOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -2302,12 +2302,12 @@ func (directLink *DirectLinkV1) UpdateGatewayMacsecWithContext(ctx context.Conte
 		return
 	}
 
-	for headerName, headerValue := range updateGatewayMacsecOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "UpdateGatewayMacsec")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "UpdateGatewayMacsec")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range updateGatewayMacsecOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -2380,12 +2380,12 @@ func (directLink *DirectLinkV1) SetGatewayMacsecWithContext(ctx context.Context,
 		return
 	}
 
-	for headerName, headerValue := range setGatewayMacsecOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "SetGatewayMacsec")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "SetGatewayMacsec")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range setGatewayMacsecOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -2477,12 +2477,12 @@ func (directLink *DirectLinkV1) ListGatewayMacsecCaksWithContext(ctx context.Con
 		return
 	}
 
-	for headerName, headerValue := range listGatewayMacsecCaksOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayMacsecCaks")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayMacsecCaks")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range listGatewayMacsecCaksOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -2548,12 +2548,12 @@ func (directLink *DirectLinkV1) CreateGatewayMacsecCakWithContext(ctx context.Co
 		return
 	}
 
-	for headerName, headerValue := range createGatewayMacsecCakOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGatewayMacsecCak")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGatewayMacsecCak")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range createGatewayMacsecCakOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -2624,7 +2624,7 @@ func (directLink *DirectLinkV1) DeleteGatewayMacsecCakWithContext(ctx context.Co
 	}
 
 	pathParamsMap := map[string]string{
-		"id":     *deleteGatewayMacsecCakOptions.ID,
+		"id": *deleteGatewayMacsecCakOptions.ID,
 		"cak_id": *deleteGatewayMacsecCakOptions.CakID,
 	}
 
@@ -2637,12 +2637,12 @@ func (directLink *DirectLinkV1) DeleteGatewayMacsecCakWithContext(ctx context.Co
 		return
 	}
 
-	for headerName, headerValue := range deleteGatewayMacsecCakOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "DeleteGatewayMacsecCak")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "DeleteGatewayMacsecCak")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range deleteGatewayMacsecCakOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 
@@ -2686,7 +2686,7 @@ func (directLink *DirectLinkV1) GetGatewayMacsecCakWithContext(ctx context.Conte
 	}
 
 	pathParamsMap := map[string]string{
-		"id":     *getGatewayMacsecCakOptions.ID,
+		"id": *getGatewayMacsecCakOptions.ID,
 		"cak_id": *getGatewayMacsecCakOptions.CakID,
 	}
 
@@ -2699,12 +2699,12 @@ func (directLink *DirectLinkV1) GetGatewayMacsecCakWithContext(ctx context.Conte
 		return
 	}
 
-	for headerName, headerValue := range getGatewayMacsecCakOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayMacsecCak")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayMacsecCak")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range getGatewayMacsecCakOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -2758,7 +2758,7 @@ func (directLink *DirectLinkV1) UpdateGatewayMacsecCakWithContext(ctx context.Co
 	}
 
 	pathParamsMap := map[string]string{
-		"id":     *updateGatewayMacsecCakOptions.ID,
+		"id": *updateGatewayMacsecCakOptions.ID,
 		"cak_id": *updateGatewayMacsecCakOptions.CakID,
 	}
 
@@ -2771,12 +2771,12 @@ func (directLink *DirectLinkV1) UpdateGatewayMacsecCakWithContext(ctx context.Co
 		return
 	}
 
-	for headerName, headerValue := range updateGatewayMacsecCakOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "UpdateGatewayMacsecCak")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "UpdateGatewayMacsecCak")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range updateGatewayMacsecCakOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -2849,12 +2849,12 @@ func (directLink *DirectLinkV1) ListGatewayRouteReportsWithContext(ctx context.C
 		return
 	}
 
-	for headerName, headerValue := range listGatewayRouteReportsOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayRouteReports")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayRouteReports")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range listGatewayRouteReportsOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -2924,12 +2924,12 @@ func (directLink *DirectLinkV1) CreateGatewayRouteReportWithContext(ctx context.
 		return
 	}
 
-	for headerName, headerValue := range createGatewayRouteReportOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGatewayRouteReport")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGatewayRouteReport")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range createGatewayRouteReportOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -2984,7 +2984,7 @@ func (directLink *DirectLinkV1) DeleteGatewayRouteReportWithContext(ctx context.
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *deleteGatewayRouteReportOptions.GatewayID,
-		"id":         *deleteGatewayRouteReportOptions.ID,
+		"id": *deleteGatewayRouteReportOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
@@ -2996,12 +2996,12 @@ func (directLink *DirectLinkV1) DeleteGatewayRouteReportWithContext(ctx context.
 		return
 	}
 
-	for headerName, headerValue := range deleteGatewayRouteReportOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "DeleteGatewayRouteReport")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "DeleteGatewayRouteReport")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range deleteGatewayRouteReportOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 
@@ -3046,7 +3046,7 @@ func (directLink *DirectLinkV1) GetGatewayRouteReportWithContext(ctx context.Con
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *getGatewayRouteReportOptions.GatewayID,
-		"id":         *getGatewayRouteReportOptions.ID,
+		"id": *getGatewayRouteReportOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -3058,12 +3058,12 @@ func (directLink *DirectLinkV1) GetGatewayRouteReportWithContext(ctx context.Con
 		return
 	}
 
-	for headerName, headerValue := range getGatewayRouteReportOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayRouteReport")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayRouteReport")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range getGatewayRouteReportOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -3130,12 +3130,12 @@ func (directLink *DirectLinkV1) ListGatewayVirtualConnectionsWithContext(ctx con
 		return
 	}
 
-	for headerName, headerValue := range listGatewayVirtualConnectionsOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayVirtualConnections")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListGatewayVirtualConnections")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range listGatewayVirtualConnectionsOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -3201,12 +3201,12 @@ func (directLink *DirectLinkV1) CreateGatewayVirtualConnectionWithContext(ctx co
 		return
 	}
 
-	for headerName, headerValue := range createGatewayVirtualConnectionOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGatewayVirtualConnection")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "CreateGatewayVirtualConnection")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range createGatewayVirtualConnectionOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -3278,7 +3278,7 @@ func (directLink *DirectLinkV1) DeleteGatewayVirtualConnectionWithContext(ctx co
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *deleteGatewayVirtualConnectionOptions.GatewayID,
-		"id":         *deleteGatewayVirtualConnectionOptions.ID,
+		"id": *deleteGatewayVirtualConnectionOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
@@ -3290,12 +3290,12 @@ func (directLink *DirectLinkV1) DeleteGatewayVirtualConnectionWithContext(ctx co
 		return
 	}
 
-	for headerName, headerValue := range deleteGatewayVirtualConnectionOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "DeleteGatewayVirtualConnection")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "DeleteGatewayVirtualConnection")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range deleteGatewayVirtualConnectionOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 
@@ -3340,7 +3340,7 @@ func (directLink *DirectLinkV1) GetGatewayVirtualConnectionWithContext(ctx conte
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *getGatewayVirtualConnectionOptions.GatewayID,
-		"id":         *getGatewayVirtualConnectionOptions.ID,
+		"id": *getGatewayVirtualConnectionOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -3352,12 +3352,12 @@ func (directLink *DirectLinkV1) GetGatewayVirtualConnectionWithContext(ctx conte
 		return
 	}
 
-	for headerName, headerValue := range getGatewayVirtualConnectionOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayVirtualConnection")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetGatewayVirtualConnection")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range getGatewayVirtualConnectionOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -3412,7 +3412,7 @@ func (directLink *DirectLinkV1) UpdateGatewayVirtualConnectionWithContext(ctx co
 
 	pathParamsMap := map[string]string{
 		"gateway_id": *updateGatewayVirtualConnectionOptions.GatewayID,
-		"id":         *updateGatewayVirtualConnectionOptions.ID,
+		"id": *updateGatewayVirtualConnectionOptions.ID,
 	}
 
 	builder := core.NewRequestBuilder(core.PATCH)
@@ -3424,12 +3424,12 @@ func (directLink *DirectLinkV1) UpdateGatewayVirtualConnectionWithContext(ctx co
 		return
 	}
 
-	for headerName, headerValue := range updateGatewayVirtualConnectionOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "UpdateGatewayVirtualConnection")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "UpdateGatewayVirtualConnection")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range updateGatewayVirtualConnectionOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -3502,12 +3502,12 @@ func (directLink *DirectLinkV1) ListOfferingTypeLocationsWithContext(ctx context
 		return
 	}
 
-	for headerName, headerValue := range listOfferingTypeLocationsOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListOfferingTypeLocations")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListOfferingTypeLocations")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range listOfferingTypeLocationsOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -3574,12 +3574,12 @@ func (directLink *DirectLinkV1) ListOfferingTypeLocationCrossConnectRoutersWithC
 		return
 	}
 
-	for headerName, headerValue := range listOfferingTypeLocationCrossConnectRoutersOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListOfferingTypeLocationCrossConnectRouters")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListOfferingTypeLocationCrossConnectRouters")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range listOfferingTypeLocationCrossConnectRoutersOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -3645,12 +3645,12 @@ func (directLink *DirectLinkV1) ListOfferingTypeSpeedsWithContext(ctx context.Co
 		return
 	}
 
-	for headerName, headerValue := range listOfferingTypeSpeedsOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListOfferingTypeSpeeds")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListOfferingTypeSpeeds")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range listOfferingTypeSpeedsOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -3708,12 +3708,12 @@ func (directLink *DirectLinkV1) ListPortsWithContext(ctx context.Context, listPo
 		return
 	}
 
-	for headerName, headerValue := range listPortsOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListPorts")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "ListPorts")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range listPortsOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -3788,12 +3788,12 @@ func (directLink *DirectLinkV1) GetPortWithContext(ctx context.Context, getPortO
 		return
 	}
 
-	for headerName, headerValue := range getPortOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetPort")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("direct_link", "V1", "GetPort")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range getPortOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -4110,11 +4110,11 @@ func UnmarshalAsPrependTemplate(m map[string]json.RawMessage, result interface{}
 // Models which "extend" this model:
 // - AuthenticationKeyIdentityKeyProtectAuthenticationKeyIdentity
 // - AuthenticationKeyIdentityHpcsAuthenticationKeyIdentity
+// - AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity
 type AuthenticationKeyIdentity struct {
 	// The CRN of the key.
 	Crn *string `json:"crn,omitempty"`
 }
-
 func (*AuthenticationKeyIdentity) isaAuthenticationKeyIdentity() bool {
 	return true
 }
@@ -4148,13 +4148,13 @@ func (authenticationKeyIdentity *AuthenticationKeyIdentity) asPatch() (_patch ma
 
 // AuthenticationKeyReference : AuthenticationKeyReference struct
 // Models which "extend" this model:
-// - AuthenticationKeyReferenceKeyProtectAuthenticationKeyReference
 // - AuthenticationKeyReferenceHpcsAuthenticationKeyReference
+// - AuthenticationKeyReferenceKeyProtectAuthenticationKeyReference
+// - AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference
 type AuthenticationKeyReference struct {
 	// The CRN of the referenced key.
 	Crn *string `json:"crn,omitempty"`
 }
-
 func (*AuthenticationKeyReference) isaAuthenticationKeyReference() bool {
 	return true
 }
@@ -4238,12 +4238,12 @@ type CreateGatewayActionOptions struct {
 // Constants associated with the CreateGatewayActionOptions.Action property.
 // Action request.
 const (
-	CreateGatewayActionOptions_Action_CreateGatewayApprove    = "create_gateway_approve"
-	CreateGatewayActionOptions_Action_CreateGatewayReject     = "create_gateway_reject"
-	CreateGatewayActionOptions_Action_DeleteGatewayApprove    = "delete_gateway_approve"
-	CreateGatewayActionOptions_Action_DeleteGatewayReject     = "delete_gateway_reject"
+	CreateGatewayActionOptions_Action_CreateGatewayApprove = "create_gateway_approve"
+	CreateGatewayActionOptions_Action_CreateGatewayReject = "create_gateway_reject"
+	CreateGatewayActionOptions_Action_DeleteGatewayApprove = "delete_gateway_approve"
+	CreateGatewayActionOptions_Action_DeleteGatewayReject = "delete_gateway_reject"
 	CreateGatewayActionOptions_Action_UpdateAttributesApprove = "update_attributes_approve"
-	CreateGatewayActionOptions_Action_UpdateAttributesReject  = "update_attributes_reject"
+	CreateGatewayActionOptions_Action_UpdateAttributesReject = "update_attributes_reject"
 )
 
 // Constants associated with the CreateGatewayActionOptions.ConnectionMode property.
@@ -4253,21 +4253,21 @@ const (
 // list of enumerated values for this property may expand in the future. Code and processes using this field must
 // tolerate unexpected values.
 const (
-	CreateGatewayActionOptions_ConnectionMode_Direct  = "direct"
+	CreateGatewayActionOptions_ConnectionMode_Direct = "direct"
 	CreateGatewayActionOptions_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the CreateGatewayActionOptions.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	CreateGatewayActionOptions_DefaultExportRouteFilter_Deny   = "deny"
+	CreateGatewayActionOptions_DefaultExportRouteFilter_Deny = "deny"
 	CreateGatewayActionOptions_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the CreateGatewayActionOptions.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	CreateGatewayActionOptions_DefaultImportRouteFilter_Deny   = "deny"
+	CreateGatewayActionOptions_DefaultImportRouteFilter_Deny = "deny"
 	CreateGatewayActionOptions_DefaultImportRouteFilter_Permit = "permit"
 )
 
@@ -4449,7 +4449,7 @@ type CreateGatewayExportRouteFilterOptions struct {
 // Constants associated with the CreateGatewayExportRouteFilterOptions.Action property.
 // Determines whether routes that match the prefix-set will be allowed (permit) or rejected (deny) through the filter.
 const (
-	CreateGatewayExportRouteFilterOptions_Action_Deny   = "deny"
+	CreateGatewayExportRouteFilterOptions_Action_Deny = "deny"
 	CreateGatewayExportRouteFilterOptions_Action_Permit = "permit"
 )
 
@@ -4457,8 +4457,8 @@ const (
 func (*DirectLinkV1) NewCreateGatewayExportRouteFilterOptions(gatewayID string, action string, prefix string) *CreateGatewayExportRouteFilterOptions {
 	return &CreateGatewayExportRouteFilterOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		Action:    core.StringPtr(action),
-		Prefix:    core.StringPtr(prefix),
+		Action: core.StringPtr(action),
+		Prefix: core.StringPtr(prefix),
 	}
 }
 
@@ -4539,7 +4539,7 @@ type CreateGatewayImportRouteFilterOptions struct {
 // Constants associated with the CreateGatewayImportRouteFilterOptions.Action property.
 // Determines whether routes that match the prefix-set will be allowed (permit) or rejected (deny) through the filter.
 const (
-	CreateGatewayImportRouteFilterOptions_Action_Deny   = "deny"
+	CreateGatewayImportRouteFilterOptions_Action_Deny = "deny"
 	CreateGatewayImportRouteFilterOptions_Action_Permit = "permit"
 )
 
@@ -4547,8 +4547,8 @@ const (
 func (*DirectLinkV1) NewCreateGatewayImportRouteFilterOptions(gatewayID string, action string, prefix string) *CreateGatewayImportRouteFilterOptions {
 	return &CreateGatewayImportRouteFilterOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		Action:    core.StringPtr(action),
-		Prefix:    core.StringPtr(prefix),
+		Action: core.StringPtr(action),
+		Prefix: core.StringPtr(prefix),
 	}
 }
 
@@ -4599,8 +4599,7 @@ type CreateGatewayMacsecCakOptions struct {
 	// Direct Link gateway identifier.
 	ID *string `json:"id" validate:"required,ne="`
 
-	// A [Hyper Protect Crypto Service Standard Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started).
-	Key *HpcsKeyIdentity `json:"key" validate:"required"`
+	Key GatewayMacsecCakKeyReferenceIntf `json:"key" validate:"required"`
 
 	// The name identifies the connectivity association key (CAK) within the MACsec key chain.
 	//
@@ -4630,15 +4629,15 @@ type CreateGatewayMacsecCakOptions struct {
 // There must be a `primary` session CAK. A `fallback` CAK is optional.
 const (
 	CreateGatewayMacsecCakOptions_Session_Fallback = "fallback"
-	CreateGatewayMacsecCakOptions_Session_Primary  = "primary"
+	CreateGatewayMacsecCakOptions_Session_Primary = "primary"
 )
 
 // NewCreateGatewayMacsecCakOptions : Instantiate CreateGatewayMacsecCakOptions
-func (*DirectLinkV1) NewCreateGatewayMacsecCakOptions(id string, key *HpcsKeyIdentity, name string, session string) *CreateGatewayMacsecCakOptions {
+func (*DirectLinkV1) NewCreateGatewayMacsecCakOptions(id string, key GatewayMacsecCakKeyReferenceIntf, name string, session string) *CreateGatewayMacsecCakOptions {
 	return &CreateGatewayMacsecCakOptions{
-		ID:      core.StringPtr(id),
-		Key:     key,
-		Name:    core.StringPtr(name),
+		ID: core.StringPtr(id),
+		Key: key,
+		Name: core.StringPtr(name),
 		Session: core.StringPtr(session),
 	}
 }
@@ -4650,7 +4649,7 @@ func (_options *CreateGatewayMacsecCakOptions) SetID(id string) *CreateGatewayMa
 }
 
 // SetKey : Allow user to set Key
-func (_options *CreateGatewayMacsecCakOptions) SetKey(key *HpcsKeyIdentity) *CreateGatewayMacsecCakOptions {
+func (_options *CreateGatewayMacsecCakOptions) SetKey(key GatewayMacsecCakKeyReferenceIntf) *CreateGatewayMacsecCakOptions {
 	_options.Key = key
 	return _options
 }
@@ -4753,15 +4752,15 @@ type CreateGatewayVirtualConnectionOptions struct {
 // The type of virtual connection.
 const (
 	CreateGatewayVirtualConnectionOptions_Type_Classic = "classic"
-	CreateGatewayVirtualConnectionOptions_Type_Vpc     = "vpc"
+	CreateGatewayVirtualConnectionOptions_Type_Vpc = "vpc"
 )
 
 // NewCreateGatewayVirtualConnectionOptions : Instantiate CreateGatewayVirtualConnectionOptions
 func (*DirectLinkV1) NewCreateGatewayVirtualConnectionOptions(gatewayID string, name string, typeVar string) *CreateGatewayVirtualConnectionOptions {
 	return &CreateGatewayVirtualConnectionOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		Name:      core.StringPtr(name),
-		Type:      core.StringPtr(typeVar),
+		Name: core.StringPtr(name),
+		Type: core.StringPtr(typeVar),
 	}
 }
 
@@ -4800,7 +4799,7 @@ type CrossConnectRouter struct {
 	// List of capabilities for this router.
 	//
 	// Listed `MacsecCapability` values indicate the router is associated with switch ports with that capability, and is
-	// able to provision direct links with that capability. Multiple `MacsecCapability` values may be listed.
+	// able to provision direct links with that capability. Multiple `MacsecCapability` values can be listed.
 	Capabilities []string `json:"capabilities,omitempty"`
 
 	// The name of the Router.
@@ -4848,7 +4847,7 @@ type DeleteGatewayExportRouteFilterOptions struct {
 func (*DirectLinkV1) NewDeleteGatewayExportRouteFilterOptions(gatewayID string, id string) *DeleteGatewayExportRouteFilterOptions {
 	return &DeleteGatewayExportRouteFilterOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID:        core.StringPtr(id),
+		ID: core.StringPtr(id),
 	}
 }
 
@@ -4886,7 +4885,7 @@ type DeleteGatewayImportRouteFilterOptions struct {
 func (*DirectLinkV1) NewDeleteGatewayImportRouteFilterOptions(gatewayID string, id string) *DeleteGatewayImportRouteFilterOptions {
 	return &DeleteGatewayImportRouteFilterOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID:        core.StringPtr(id),
+		ID: core.StringPtr(id),
 	}
 }
 
@@ -4923,7 +4922,7 @@ type DeleteGatewayMacsecCakOptions struct {
 // NewDeleteGatewayMacsecCakOptions : Instantiate DeleteGatewayMacsecCakOptions
 func (*DirectLinkV1) NewDeleteGatewayMacsecCakOptions(id string, cakID string) *DeleteGatewayMacsecCakOptions {
 	return &DeleteGatewayMacsecCakOptions{
-		ID:    core.StringPtr(id),
+		ID: core.StringPtr(id),
 		CakID: core.StringPtr(cakID),
 	}
 }
@@ -4990,7 +4989,7 @@ type DeleteGatewayRouteReportOptions struct {
 func (*DirectLinkV1) NewDeleteGatewayRouteReportOptions(gatewayID string, id string) *DeleteGatewayRouteReportOptions {
 	return &DeleteGatewayRouteReportOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID:        core.StringPtr(id),
+		ID: core.StringPtr(id),
 	}
 }
 
@@ -5028,7 +5027,7 @@ type DeleteGatewayVirtualConnectionOptions struct {
 func (*DirectLinkV1) NewDeleteGatewayVirtualConnectionOptions(gatewayID string, id string) *DeleteGatewayVirtualConnectionOptions {
 	return &DeleteGatewayVirtualConnectionOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID:        core.StringPtr(id),
+		ID: core.StringPtr(id),
 	}
 }
 
@@ -5158,7 +5157,7 @@ type Gateway struct {
 	// Gateway location.
 	LocationName *string `json:"location_name" validate:"required"`
 
-	// MACsec configuration information of a Direct Link gateway.
+	// MACsec configuration information of a direct link.
 	Macsec *GatewayMacsecReference `json:"macsec,omitempty"`
 
 	// Indicates the direct link's MACsec capability. It must match one of the MACsec related `capabilities` of the
@@ -5166,9 +5165,9 @@ type Gateway struct {
 	//
 	// Only included on type=dedicated direct links.
 	//
-	// - non_macsec: The direct link does not support MACsec.
-	// - macsec: The direct link supports MACsec. The MACsec feature must be enabled.
-	// - macsec_optional: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
+	// - `non_macsec`: The direct link does not support MACsec.
+	// - `macsec`: The direct link supports MACsec. The MACsec feature must be enabled.
+	// - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 	// direct link creation.
 	MacsecCapability *string `json:"macsec_capability,omitempty"`
 
@@ -5216,10 +5215,10 @@ type Gateway struct {
 // Gateway BGP status. The list of enumerated values for this property may expand in the future. Code and processes
 // using this field  must tolerate unexpected values.
 const (
-	Gateway_BgpStatus_Active      = "active"
-	Gateway_BgpStatus_Connect     = "connect"
+	Gateway_BgpStatus_Active = "active"
+	Gateway_BgpStatus_Connect = "connect"
 	Gateway_BgpStatus_Established = "established"
-	Gateway_BgpStatus_Idle        = "idle"
+	Gateway_BgpStatus_Idle = "idle"
 )
 
 // Constants associated with the Gateway.ConnectionMode property.
@@ -5227,21 +5226,21 @@ const (
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	Gateway_ConnectionMode_Direct  = "direct"
+	Gateway_ConnectionMode_Direct = "direct"
 	Gateway_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the Gateway.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	Gateway_DefaultExportRouteFilter_Deny   = "deny"
+	Gateway_DefaultExportRouteFilter_Deny = "deny"
 	Gateway_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the Gateway.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	Gateway_DefaultImportRouteFilter_Deny   = "deny"
+	Gateway_DefaultImportRouteFilter_Deny = "deny"
 	Gateway_DefaultImportRouteFilter_Permit = "permit"
 )
 
@@ -5250,7 +5249,7 @@ const (
 // expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
 	Gateway_LinkStatus_Down = "down"
-	Gateway_LinkStatus_Up   = "up"
+	Gateway_LinkStatus_Up = "up"
 )
 
 // Constants associated with the Gateway.MacsecCapability property.
@@ -5259,14 +5258,14 @@ const (
 //
 // Only included on type=dedicated direct links.
 //
-// - non_macsec: The direct link does not support MACsec.
-// - macsec: The direct link supports MACsec. The MACsec feature must be enabled.
-// - macsec_optional: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
+// - `non_macsec`: The direct link does not support MACsec.
+// - `macsec`: The direct link supports MACsec. The MACsec feature must be enabled.
+// - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 // direct link creation.
 const (
-	Gateway_MacsecCapability_Macsec         = "macsec"
+	Gateway_MacsecCapability_Macsec = "macsec"
 	Gateway_MacsecCapability_MacsecOptional = "macsec_optional"
-	Gateway_MacsecCapability_NonMacsec      = "non_macsec"
+	Gateway_MacsecCapability_NonMacsec = "non_macsec"
 )
 
 // Constants associated with the Gateway.OperationalStatus property.
@@ -5276,26 +5275,26 @@ const (
 // See `operational_status_reasons[]` for possible remediation of the `failed` `operational_status`.
 const (
 	Gateway_OperationalStatus_AwaitingCompletionNotice = "awaiting_completion_notice"
-	Gateway_OperationalStatus_AwaitingLoa              = "awaiting_loa"
+	Gateway_OperationalStatus_AwaitingLoa = "awaiting_loa"
 	Gateway_OperationalStatus_CompletionNoticeApproved = "completion_notice_approved"
 	Gateway_OperationalStatus_CompletionNoticeReceived = "completion_notice_received"
 	Gateway_OperationalStatus_CompletionNoticeRejected = "completion_notice_rejected"
-	Gateway_OperationalStatus_Configuring              = "configuring"
-	Gateway_OperationalStatus_CreatePending            = "create_pending"
-	Gateway_OperationalStatus_CreateRejected           = "create_rejected"
-	Gateway_OperationalStatus_DeletePending            = "delete_pending"
-	Gateway_OperationalStatus_Failed                   = "failed"
-	Gateway_OperationalStatus_LoaAccepted              = "loa_accepted"
-	Gateway_OperationalStatus_LoaCreated               = "loa_created"
-	Gateway_OperationalStatus_LoaRejected              = "loa_rejected"
-	Gateway_OperationalStatus_Provisioned              = "provisioned"
+	Gateway_OperationalStatus_Configuring = "configuring"
+	Gateway_OperationalStatus_CreatePending = "create_pending"
+	Gateway_OperationalStatus_CreateRejected = "create_rejected"
+	Gateway_OperationalStatus_DeletePending = "delete_pending"
+	Gateway_OperationalStatus_Failed = "failed"
+	Gateway_OperationalStatus_LoaAccepted = "loa_accepted"
+	Gateway_OperationalStatus_LoaCreated = "loa_created"
+	Gateway_OperationalStatus_LoaRejected = "loa_rejected"
+	Gateway_OperationalStatus_Provisioned = "provisioned"
 )
 
 // Constants associated with the Gateway.Type property.
 // Offering type. The list of enumerated values for this property may expand in the future. Code and processes using
 // this field  must tolerate unexpected values.
 const (
-	Gateway_Type_Connect   = "connect"
+	Gateway_Type_Connect = "connect"
 	Gateway_Type_Dedicated = "dedicated"
 )
 
@@ -5541,7 +5540,6 @@ type GatewayActionTemplateUpdatesItem struct {
 	// VLAN to be updated for this gateway.
 	Vlan *int64 `json:"vlan,omitempty"`
 }
-
 func (*GatewayActionTemplateUpdatesItem) isaGatewayActionTemplateUpdatesItem() bool {
 	return true
 }
@@ -5605,7 +5603,7 @@ type GatewayBfdConfig struct {
 const (
 	GatewayBfdConfig_BfdStatus_Down = "down"
 	GatewayBfdConfig_BfdStatus_Init = "init"
-	GatewayBfdConfig_BfdStatus_Up   = "up"
+	GatewayBfdConfig_BfdStatus_Up = "up"
 )
 
 // UnmarshalGatewayBfdConfig unmarshals an instance of GatewayBfdConfig from the specified map of raw messages.
@@ -5773,7 +5771,6 @@ type GatewayChangeRequest struct {
 const (
 	GatewayChangeRequest_Type_CreateGateway = "create_gateway"
 )
-
 func (*GatewayChangeRequest) isaGatewayChangeRequest() bool {
 	return true
 }
@@ -5834,7 +5831,6 @@ type GatewayChangeRequestGatewayClientGatewayUpdateAttributesUpdatesItem struct 
 	// VLAN to be updated for this gateway.
 	Vlan *int64 `json:"vlan,omitempty"`
 }
-
 func (*GatewayChangeRequestGatewayClientGatewayUpdateAttributesUpdatesItem) isaGatewayChangeRequestGatewayClientGatewayUpdateAttributesUpdatesItem() bool {
 	return true
 }
@@ -5910,7 +5906,6 @@ type GatewayChangeRequestUpdatesItem struct {
 	// VLAN to be updated for this gateway.
 	Vlan *int64 `json:"vlan,omitempty"`
 }
-
 func (*GatewayChangeRequestUpdatesItem) isaGatewayChangeRequestUpdatesItem() bool {
 	return true
 }
@@ -6062,7 +6057,7 @@ type GatewayCollectionGatewaysItem struct {
 	// Gateway location.
 	LocationName *string `json:"location_name,omitempty"`
 
-	// MACsec configuration information of a Direct Link gateway.
+	// MACsec configuration information of a direct link.
 	Macsec *GatewayMacsecReference `json:"macsec,omitempty"`
 
 	// Indicates the direct link's MACsec capability. It must match one of the MACsec related `capabilities` of the
@@ -6070,9 +6065,9 @@ type GatewayCollectionGatewaysItem struct {
 	//
 	// Only included on type=dedicated direct links.
 	//
-	// - non_macsec: The direct link does not support MACsec.
-	// - macsec: The direct link supports MACsec. The MACsec feature must be enabled.
-	// - macsec_optional: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
+	// - `non_macsec`: The direct link does not support MACsec.
+	// - `macsec`: The direct link supports MACsec. The MACsec feature must be enabled.
+	// - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 	// direct link creation.
 	MacsecCapability *string `json:"macsec_capability,omitempty"`
 
@@ -6120,10 +6115,10 @@ type GatewayCollectionGatewaysItem struct {
 // Gateway BGP status. The list of enumerated values for this property may expand in the future. Code and processes
 // using this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItem_BgpStatus_Active      = "active"
-	GatewayCollectionGatewaysItem_BgpStatus_Connect     = "connect"
+	GatewayCollectionGatewaysItem_BgpStatus_Active = "active"
+	GatewayCollectionGatewaysItem_BgpStatus_Connect = "connect"
 	GatewayCollectionGatewaysItem_BgpStatus_Established = "established"
-	GatewayCollectionGatewaysItem_BgpStatus_Idle        = "idle"
+	GatewayCollectionGatewaysItem_BgpStatus_Idle = "idle"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItem.ConnectionMode property.
@@ -6131,21 +6126,21 @@ const (
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItem_ConnectionMode_Direct  = "direct"
+	GatewayCollectionGatewaysItem_ConnectionMode_Direct = "direct"
 	GatewayCollectionGatewaysItem_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItem.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayCollectionGatewaysItem_DefaultExportRouteFilter_Deny   = "deny"
+	GatewayCollectionGatewaysItem_DefaultExportRouteFilter_Deny = "deny"
 	GatewayCollectionGatewaysItem_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItem.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayCollectionGatewaysItem_DefaultImportRouteFilter_Deny   = "deny"
+	GatewayCollectionGatewaysItem_DefaultImportRouteFilter_Deny = "deny"
 	GatewayCollectionGatewaysItem_DefaultImportRouteFilter_Permit = "permit"
 )
 
@@ -6154,7 +6149,7 @@ const (
 // expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
 	GatewayCollectionGatewaysItem_LinkStatus_Down = "down"
-	GatewayCollectionGatewaysItem_LinkStatus_Up   = "up"
+	GatewayCollectionGatewaysItem_LinkStatus_Up = "up"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItem.MacsecCapability property.
@@ -6163,14 +6158,14 @@ const (
 //
 // Only included on type=dedicated direct links.
 //
-// - non_macsec: The direct link does not support MACsec.
-// - macsec: The direct link supports MACsec. The MACsec feature must be enabled.
-// - macsec_optional: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
+// - `non_macsec`: The direct link does not support MACsec.
+// - `macsec`: The direct link supports MACsec. The MACsec feature must be enabled.
+// - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 // direct link creation.
 const (
-	GatewayCollectionGatewaysItem_MacsecCapability_Macsec         = "macsec"
+	GatewayCollectionGatewaysItem_MacsecCapability_Macsec = "macsec"
 	GatewayCollectionGatewaysItem_MacsecCapability_MacsecOptional = "macsec_optional"
-	GatewayCollectionGatewaysItem_MacsecCapability_NonMacsec      = "non_macsec"
+	GatewayCollectionGatewaysItem_MacsecCapability_NonMacsec = "non_macsec"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItem.OperationalStatus property.
@@ -6180,29 +6175,28 @@ const (
 // See `operational_status_reasons[]` for possible remediation of the `failed` `operational_status`.
 const (
 	GatewayCollectionGatewaysItem_OperationalStatus_AwaitingCompletionNotice = "awaiting_completion_notice"
-	GatewayCollectionGatewaysItem_OperationalStatus_AwaitingLoa              = "awaiting_loa"
+	GatewayCollectionGatewaysItem_OperationalStatus_AwaitingLoa = "awaiting_loa"
 	GatewayCollectionGatewaysItem_OperationalStatus_CompletionNoticeApproved = "completion_notice_approved"
 	GatewayCollectionGatewaysItem_OperationalStatus_CompletionNoticeReceived = "completion_notice_received"
 	GatewayCollectionGatewaysItem_OperationalStatus_CompletionNoticeRejected = "completion_notice_rejected"
-	GatewayCollectionGatewaysItem_OperationalStatus_Configuring              = "configuring"
-	GatewayCollectionGatewaysItem_OperationalStatus_CreatePending            = "create_pending"
-	GatewayCollectionGatewaysItem_OperationalStatus_CreateRejected           = "create_rejected"
-	GatewayCollectionGatewaysItem_OperationalStatus_DeletePending            = "delete_pending"
-	GatewayCollectionGatewaysItem_OperationalStatus_Failed                   = "failed"
-	GatewayCollectionGatewaysItem_OperationalStatus_LoaAccepted              = "loa_accepted"
-	GatewayCollectionGatewaysItem_OperationalStatus_LoaCreated               = "loa_created"
-	GatewayCollectionGatewaysItem_OperationalStatus_LoaRejected              = "loa_rejected"
-	GatewayCollectionGatewaysItem_OperationalStatus_Provisioned              = "provisioned"
+	GatewayCollectionGatewaysItem_OperationalStatus_Configuring = "configuring"
+	GatewayCollectionGatewaysItem_OperationalStatus_CreatePending = "create_pending"
+	GatewayCollectionGatewaysItem_OperationalStatus_CreateRejected = "create_rejected"
+	GatewayCollectionGatewaysItem_OperationalStatus_DeletePending = "delete_pending"
+	GatewayCollectionGatewaysItem_OperationalStatus_Failed = "failed"
+	GatewayCollectionGatewaysItem_OperationalStatus_LoaAccepted = "loa_accepted"
+	GatewayCollectionGatewaysItem_OperationalStatus_LoaCreated = "loa_created"
+	GatewayCollectionGatewaysItem_OperationalStatus_LoaRejected = "loa_rejected"
+	GatewayCollectionGatewaysItem_OperationalStatus_Provisioned = "provisioned"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItem.Type property.
 // Offering type. The list of enumerated values for this property may expand in the future. Code and processes using
 // this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItem_Type_Connect   = "connect"
+	GatewayCollectionGatewaysItem_Type_Connect = "connect"
 	GatewayCollectionGatewaysItem_Type_Dedicated = "dedicated"
 )
-
 func (*GatewayCollectionGatewaysItem) isaGatewayCollectionGatewaysItem() bool {
 	return true
 }
@@ -6418,9 +6412,9 @@ func UnmarshalGatewayCollectionGatewaysItem(m map[string]json.RawMessage, result
 	return
 }
 
-// GatewayMacsec : MACsec configuration information of a Direct Link gateway.
+// GatewayMacsec : MACsec configuration information of a direct link.
 type GatewayMacsec struct {
-	// Indicates if the MACsec feature is currently active (true) or inactive (false) for a gateway.
+	// Indicates if the MACsec feature is currently active (true) or inactive (false) for a direct link.
 	Active *bool `json:"active" validate:"required"`
 
 	// The cipher suite used in generating the security association key (SAK).
@@ -6444,10 +6438,10 @@ type GatewayMacsec struct {
 
 	// Determines how packets without MACsec headers are handled.
 	//
-	// `must_secure` - Packets without MACsec headers are dropped. This policy should be used to prefer security over
-	// network availability.
-	// `should_secure` - Packets without MACsec headers are allowed. This policy should be used to prefer network
-	// availability over security.
+	// - `must_secure` - Packets without MACsec headers are dropped. Use this policy to prefer security over network
+	// availability.
+	// - `should_secure` - Packets without MACsec headers are allowed. Use this policy to prefer network availability over
+	// security.
 	SecurityPolicy *string `json:"security_policy" validate:"required"`
 
 	// Current status of MACsec on this direct link.
@@ -6482,12 +6476,12 @@ const (
 // Constants associated with the GatewayMacsec.SecurityPolicy property.
 // Determines how packets without MACsec headers are handled.
 //
-// `must_secure` - Packets without MACsec headers are dropped. This policy should be used to prefer security over
-// network availability.
-// `should_secure` - Packets without MACsec headers are allowed. This policy should be used to prefer network
-// availability over security.
+// - `must_secure` - Packets without MACsec headers are dropped. Use this policy to prefer security over network
+// availability.
+// - `should_secure` - Packets without MACsec headers are allowed. Use this policy to prefer network availability over
+// security.
 const (
-	GatewayMacsec_SecurityPolicy_MustSecure   = "must_secure"
+	GatewayMacsec_SecurityPolicy_MustSecure = "must_secure"
 	GatewayMacsec_SecurityPolicy_ShouldSecure = "should_secure"
 )
 
@@ -6502,11 +6496,11 @@ const (
 // See `status_reasons[]` for possible remediation of the `failed` `status`.
 const (
 	GatewayMacsec_Status_Deleting = "deleting"
-	GatewayMacsec_Status_Failed   = "failed"
-	GatewayMacsec_Status_Init     = "init"
-	GatewayMacsec_Status_Offline  = "offline"
-	GatewayMacsec_Status_Pending  = "pending"
-	GatewayMacsec_Status_Secured  = "secured"
+	GatewayMacsec_Status_Failed = "failed"
+	GatewayMacsec_Status_Init = "init"
+	GatewayMacsec_Status_Offline = "offline"
+	GatewayMacsec_Status_Pending = "pending"
+	GatewayMacsec_Status_Secured = "secured"
 )
 
 // UnmarshalGatewayMacsec unmarshals an instance of GatewayMacsec from the specified map of raw messages.
@@ -6578,10 +6572,10 @@ func UnmarshalGatewayMacsec(m map[string]json.RawMessage, result interface{}) (e
 // Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started) type=standard with key material a hexadecimal
 // string exactly 64 characters in length.
 type GatewayMacsecCak struct {
-	// This field will be present when the `status` of the MACsec CAK is `rotating` and may be present when the `status` is
-	// `failed`.
+	// This field will be present when the `status` of the MACsec CAK is `rotating` or `inactive`. It might be present when
+	// the CAK `status` is `failed`.
 	//
-	// This object denotes the MACsec CAK's values prior to beginning the rotation and represent the previous key still
+	// This object denotes the MACsec CAK's values prior to beginning a CAK rotation and represents the previous key still
 	// configured in the direct link's MACsec key chain.
 	//
 	// This object will be removed when the MACsec CAK rotation completes, indicating that the previous key has been
@@ -6594,9 +6588,7 @@ type GatewayMacsecCak struct {
 	// The unique identifier for this connectivity association key (CAK).
 	ID *string `json:"id" validate:"required"`
 
-	// A reference to a [Hyper Protect Crypto Service Standard
-	// Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started).
-	Key *HpcsKeyReference `json:"key" validate:"required"`
+	Key GatewayMacsecCakKeyReferenceIntf `json:"key" validate:"required"`
 
 	// The name identifies the connectivity association key (CAK) within the MACsec key chain.
 	//
@@ -6617,11 +6609,18 @@ type GatewayMacsecCak struct {
 	//
 	// Status `operational` is returned when the CAK is configured successfully.
 	//
+	// Status `rotating` is returned during a key rotation. The CAK defined by `active_delta` is still configured on the
+	// device and could be securing the MACsec session. In the case of a primary CAK, the status will be `rotating` for a
+	// period of time while waiting for the MACsec session to be secured with the new CAK. After that time, the CAK will
+	// either enter `active` or `inactive` status.
+	//
 	// Status `active` is returned when the CAK is configured successfully and is currently used to secure the MACsec
 	// session.
 	//
-	// Status `rotating` is returned during a key rotation. The CAK defined by `active_delta` is securing the MACsec
-	// session. The status will remain `rotating` until the new key is `active`.
+	// Status `inactive` is returned when the CAK is configured successfully, but is not currently used to secure the
+	// MACsec session. The CAK might enter `rotating` status, and ultimately the `active` status, if it is found to be used
+	// to secure the MACsec session. The CAK might never leave this status on its own (e.g. if there is a key/key name
+	// mismatch). You are allowed to patch the CAK in this state to start the rotation procedure again.
 	//
 	// Status `failed` is returned when the CAK cannot be configured. To recover, first resolve any issues with your HPCS
 	// key, then patch this CAK with the same or new key. Alternatively, you can delete this CAK if used for the `fallback`
@@ -6641,7 +6640,7 @@ type GatewayMacsecCak struct {
 // There must be a `primary` session CAK. A `fallback` CAK is optional.
 const (
 	GatewayMacsecCak_Session_Fallback = "fallback"
-	GatewayMacsecCak_Session_Primary  = "primary"
+	GatewayMacsecCak_Session_Primary = "primary"
 )
 
 // Constants associated with the GatewayMacsecCak.Status property.
@@ -6649,20 +6648,28 @@ const (
 //
 // Status `operational` is returned when the CAK is configured successfully.
 //
+// Status `rotating` is returned during a key rotation. The CAK defined by `active_delta` is still configured on the
+// device and could be securing the MACsec session. In the case of a primary CAK, the status will be `rotating` for a
+// period of time while waiting for the MACsec session to be secured with the new CAK. After that time, the CAK will
+// either enter `active` or `inactive` status.
+//
 // Status `active` is returned when the CAK is configured successfully and is currently used to secure the MACsec
 // session.
 //
-// Status `rotating` is returned during a key rotation. The CAK defined by `active_delta` is securing the MACsec
-// session. The status will remain `rotating` until the new key is `active`.
+// Status `inactive` is returned when the CAK is configured successfully, but is not currently used to secure the MACsec
+// session. The CAK might enter `rotating` status, and ultimately the `active` status, if it is found to be used to
+// secure the MACsec session. The CAK might never leave this status on its own (e.g. if there is a key/key name
+// mismatch). You are allowed to patch the CAK in this state to start the rotation procedure again.
 //
 // Status `failed` is returned when the CAK cannot be configured. To recover, first resolve any issues with your HPCS
 // key, then patch this CAK with the same or new key. Alternatively, you can delete this CAK if used for the `fallback`
 // session.
 const (
-	GatewayMacsecCak_Status_Active      = "active"
-	GatewayMacsecCak_Status_Failed      = "failed"
+	GatewayMacsecCak_Status_Active = "active"
+	GatewayMacsecCak_Status_Failed = "failed"
+	GatewayMacsecCak_Status_Inactive = "inactive"
 	GatewayMacsecCak_Status_Operational = "operational"
-	GatewayMacsecCak_Status_Rotating    = "rotating"
+	GatewayMacsecCak_Status_Rotating = "rotating"
 )
 
 // UnmarshalGatewayMacsecCak unmarshals an instance of GatewayMacsecCak from the specified map of raw messages.
@@ -6683,7 +6690,7 @@ func UnmarshalGatewayMacsecCak(m map[string]json.RawMessage, result interface{})
 		err = core.SDKErrorf(err, "", "id-error", common.GetComponentInfo())
 		return
 	}
-	err = core.UnmarshalModel(m, "key", &obj.Key, UnmarshalHpcsKeyReference)
+	err = core.UnmarshalModel(m, "key", &obj.Key, UnmarshalGatewayMacsecCakKeyReference)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "key-error", common.GetComponentInfo())
 		return
@@ -6712,31 +6719,80 @@ func UnmarshalGatewayMacsecCak(m map[string]json.RawMessage, result interface{})
 	return
 }
 
-// GatewayMacsecCakActiveDelta : This field will be present when the `status` of the MACsec CAK is `rotating` and may be present when the `status` is
-// `failed`.
+// GatewayMacsecCakActiveDelta : This field will be present when the `status` of the MACsec CAK is `rotating` or `inactive`. It might be present when
+// the CAK `status` is `failed`.
 //
-// This object denotes the MACsec CAK's values prior to beginning the rotation and represent the previous key still
+// This object denotes the MACsec CAK's values prior to beginning a CAK rotation and represents the previous key still
 // configured in the direct link's MACsec key chain.
 //
 // This object will be removed when the MACsec CAK rotation completes, indicating that the previous key has been removed
 // from the key chain, and the current CAK's values are in use.
 type GatewayMacsecCakActiveDelta struct {
-	// A reference to a [Hyper Protect Crypto Service Standard
-	// Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started).
-	Key *HpcsKeyReference `json:"key,omitempty"`
+	Key GatewayMacsecCakKeyReferenceIntf `json:"key" validate:"required"`
 
 	// The name identifies the connectivity association key (CAK) within the MACsec key chain.
 	//
 	// The CAK's `name` must be a hexadecimal string of even lengths between 2 to 64 inclusive.
 	//
 	// This value, along with the material of the `key`, must match on the MACsec peers.
-	Name *string `json:"name,omitempty"`
+	Name *string `json:"name" validate:"required"`
+
+	// Current status of the CAK.
+	//
+	// Status `operational` is returned when the CAK is configured successfully.
+	//
+	// Status `rotating` is returned during a key rotation. The CAK defined by `active_delta` is still configured on the
+	// device and could be securing the MACsec session. In the case of a primary CAK, the status will be `rotating` for a
+	// period of time while waiting for the MACsec session to be secured with the new CAK. After that time, the CAK will
+	// either enter `active` or `inactive` status.
+	//
+	// Status `active` is returned when the CAK is configured successfully and is currently used to secure the MACsec
+	// session.
+	//
+	// Status `inactive` is returned when the CAK is configured successfully, but is not currently used to secure the
+	// MACsec session. The CAK might enter `rotating` status, and ultimately the `active` status, if it is found to be used
+	// to secure the MACsec session. The CAK might never leave this status on its own (e.g. if there is a key/key name
+	// mismatch). You are allowed to patch the CAK in this state to start the rotation procedure again.
+	//
+	// Status `failed` is returned when the CAK cannot be configured. To recover, first resolve any issues with your HPCS
+	// key, then patch this CAK with the same or new key. Alternatively, you can delete this CAK if used for the `fallback`
+	// session.
+	Status *string `json:"status" validate:"required"`
 }
+
+// Constants associated with the GatewayMacsecCakActiveDelta.Status property.
+// Current status of the CAK.
+//
+// Status `operational` is returned when the CAK is configured successfully.
+//
+// Status `rotating` is returned during a key rotation. The CAK defined by `active_delta` is still configured on the
+// device and could be securing the MACsec session. In the case of a primary CAK, the status will be `rotating` for a
+// period of time while waiting for the MACsec session to be secured with the new CAK. After that time, the CAK will
+// either enter `active` or `inactive` status.
+//
+// Status `active` is returned when the CAK is configured successfully and is currently used to secure the MACsec
+// session.
+//
+// Status `inactive` is returned when the CAK is configured successfully, but is not currently used to secure the MACsec
+// session. The CAK might enter `rotating` status, and ultimately the `active` status, if it is found to be used to
+// secure the MACsec session. The CAK might never leave this status on its own (e.g. if there is a key/key name
+// mismatch). You are allowed to patch the CAK in this state to start the rotation procedure again.
+//
+// Status `failed` is returned when the CAK cannot be configured. To recover, first resolve any issues with your HPCS
+// key, then patch this CAK with the same or new key. Alternatively, you can delete this CAK if used for the `fallback`
+// session.
+const (
+	GatewayMacsecCakActiveDelta_Status_Active = "active"
+	GatewayMacsecCakActiveDelta_Status_Failed = "failed"
+	GatewayMacsecCakActiveDelta_Status_Inactive = "inactive"
+	GatewayMacsecCakActiveDelta_Status_Operational = "operational"
+	GatewayMacsecCakActiveDelta_Status_Rotating = "rotating"
+)
 
 // UnmarshalGatewayMacsecCakActiveDelta unmarshals an instance of GatewayMacsecCakActiveDelta from the specified map of raw messages.
 func UnmarshalGatewayMacsecCakActiveDelta(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(GatewayMacsecCakActiveDelta)
-	err = core.UnmarshalModel(m, "key", &obj.Key, UnmarshalHpcsKeyReference)
+	err = core.UnmarshalModel(m, "key", &obj.Key, UnmarshalGatewayMacsecCakKeyReference)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "key-error", common.GetComponentInfo())
 		return
@@ -6744,6 +6800,11 @@ func UnmarshalGatewayMacsecCakActiveDelta(m map[string]json.RawMessage, result i
 	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "name-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "status", &obj.Status)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "status-error", common.GetComponentInfo())
 		return
 	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
@@ -6768,13 +6829,51 @@ func UnmarshalGatewayMacsecCakCollection(m map[string]json.RawMessage, result in
 	return
 }
 
+// GatewayMacsecCakKeyReference : GatewayMacsecCakKeyReference struct
+// Models which "extend" this model:
+// - GatewayMacsecCakKeyReferenceHpcsCakKeyReference
+// - GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference
+type GatewayMacsecCakKeyReference struct {
+	// The CRN of the referenced key.
+	Crn *string `json:"crn,omitempty"`
+}
+func (*GatewayMacsecCakKeyReference) isaGatewayMacsecCakKeyReference() bool {
+	return true
+}
+
+type GatewayMacsecCakKeyReferenceIntf interface {
+	isaGatewayMacsecCakKeyReference() bool
+	asPatch() map[string]interface{}
+}
+
+// UnmarshalGatewayMacsecCakKeyReference unmarshals an instance of GatewayMacsecCakKeyReference from the specified map of raw messages.
+func UnmarshalGatewayMacsecCakKeyReference(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(GatewayMacsecCakKeyReference)
+	err = core.UnmarshalPrimitive(m, "crn", &obj.Crn)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "crn-error", common.GetComponentInfo())
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// asPatch returns a generic map representation of the GatewayMacsecCakKeyReference
+func (gatewayMacsecCakKeyReference *GatewayMacsecCakKeyReference) asPatch() (_patch map[string]interface{}) {
+	_patch = map[string]interface{}{}
+	if !core.IsNil(gatewayMacsecCakKeyReference.Crn) {
+		_patch["crn"] = gatewayMacsecCakKeyReference.Crn
+	}
+
+	return
+}
+
 // GatewayMacsecCakPatch : Patch fields for CAK of MACsec configuration on a direct link.
 //
 // When rotating a CAK, patch both the `name` and `key` fields simultaneously. Both must have new values and cannot
 // match with another CAK. Neither `name` nor `key` is allowed to be patched on its own.
 type GatewayMacsecCakPatch struct {
-	// A [Hyper Protect Crypto Service Standard Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started).
-	Key *HpcsKeyIdentity `json:"key,omitempty"`
+	Key GatewayMacsecCakKeyReferenceIntf `json:"key,omitempty"`
 
 	// The name identifies the connectivity association key (CAK) within the MACsec key chain.
 	//
@@ -6787,7 +6886,7 @@ type GatewayMacsecCakPatch struct {
 // UnmarshalGatewayMacsecCakPatch unmarshals an instance of GatewayMacsecCakPatch from the specified map of raw messages.
 func UnmarshalGatewayMacsecCakPatch(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(GatewayMacsecCakPatch)
-	err = core.UnmarshalModel(m, "key", &obj.Key, UnmarshalHpcsKeyIdentity)
+	err = core.UnmarshalModel(m, "key", &obj.Key, UnmarshalGatewayMacsecCakKeyReference)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "key-error", common.GetComponentInfo())
 		return
@@ -6816,8 +6915,7 @@ func (gatewayMacsecCakPatch *GatewayMacsecCakPatch) AsPatch() (_patch map[string
 
 // GatewayMacsecCakPrototype : The prototype for a connectivity association key (CAK) used in the MACsec Key Agreement (MKA) protocol.
 type GatewayMacsecCakPrototype struct {
-	// A [Hyper Protect Crypto Service Standard Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started).
-	Key *HpcsKeyIdentity `json:"key" validate:"required"`
+	Key GatewayMacsecCakKeyReferenceIntf `json:"key" validate:"required"`
 
 	// The name identifies the connectivity association key (CAK) within the MACsec key chain.
 	//
@@ -6844,14 +6942,14 @@ type GatewayMacsecCakPrototype struct {
 // There must be a `primary` session CAK. A `fallback` CAK is optional.
 const (
 	GatewayMacsecCakPrototype_Session_Fallback = "fallback"
-	GatewayMacsecCakPrototype_Session_Primary  = "primary"
+	GatewayMacsecCakPrototype_Session_Primary = "primary"
 )
 
 // NewGatewayMacsecCakPrototype : Instantiate GatewayMacsecCakPrototype (Generic Model Constructor)
-func (*DirectLinkV1) NewGatewayMacsecCakPrototype(key *HpcsKeyIdentity, name string, session string) (_model *GatewayMacsecCakPrototype, err error) {
+func (*DirectLinkV1) NewGatewayMacsecCakPrototype(key GatewayMacsecCakKeyReferenceIntf, name string, session string) (_model *GatewayMacsecCakPrototype, err error) {
 	_model = &GatewayMacsecCakPrototype{
-		Key:     key,
-		Name:    core.StringPtr(name),
+		Key: key,
+		Name: core.StringPtr(name),
 		Session: core.StringPtr(session),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -6864,7 +6962,7 @@ func (*DirectLinkV1) NewGatewayMacsecCakPrototype(key *HpcsKeyIdentity, name str
 // UnmarshalGatewayMacsecCakPrototype unmarshals an instance of GatewayMacsecCakPrototype from the specified map of raw messages.
 func UnmarshalGatewayMacsecCakPrototype(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(GatewayMacsecCakPrototype)
-	err = core.UnmarshalModel(m, "key", &obj.Key, UnmarshalHpcsKeyIdentity)
+	err = core.UnmarshalModel(m, "key", &obj.Key, UnmarshalGatewayMacsecCakKeyReference)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "key-error", common.GetComponentInfo())
 		return
@@ -6883,9 +6981,9 @@ func UnmarshalGatewayMacsecCakPrototype(m map[string]json.RawMessage, result int
 	return
 }
 
-// GatewayMacsecPatch : Patch fields for MACsec configuration of a Direct Link gateway.
+// GatewayMacsecPatch : Patch fields for MACsec configuration of a direct link.
 type GatewayMacsecPatch struct {
-	// Sets the MACsec feature to be active (true) or inactive (false) for a gateway.
+	// Sets the MACsec feature to be active (true) or inactive (false) for a direct link.
 	Active *bool `json:"active,omitempty"`
 
 	// Determines how SAK rekeying occurs. It is either timer based or based on the amount of used packet numbers.
@@ -6893,10 +6991,10 @@ type GatewayMacsecPatch struct {
 
 	// Determines how packets without MACsec headers are handled.
 	//
-	// `must_secure` - Packets without MACsec headers are dropped. This policy should be used to prefer security over
-	// network availability.
-	// `should_secure` - Packets without MACsec headers are allowed. This policy should be used to prefer network
-	// availability over security.
+	// - `must_secure` - Packets without MACsec headers are dropped. Use this policy to prefer security over network
+	// availability.
+	// - `should_secure` - Packets without MACsec headers are allowed. Use this policy to prefer network availability over
+	// security.
 	SecurityPolicy *string `json:"security_policy,omitempty"`
 
 	// The window size determines the number of frames in a window for replay protection.
@@ -6909,12 +7007,12 @@ type GatewayMacsecPatch struct {
 // Constants associated with the GatewayMacsecPatch.SecurityPolicy property.
 // Determines how packets without MACsec headers are handled.
 //
-// `must_secure` - Packets without MACsec headers are dropped. This policy should be used to prefer security over
-// network availability.
-// `should_secure` - Packets without MACsec headers are allowed. This policy should be used to prefer network
-// availability over security.
+// - `must_secure` - Packets without MACsec headers are dropped. Use this policy to prefer security over network
+// availability.
+// - `should_secure` - Packets without MACsec headers are allowed. Use this policy to prefer network availability over
+// security.
 const (
-	GatewayMacsecPatch_SecurityPolicy_MustSecure   = "must_secure"
+	GatewayMacsecPatch_SecurityPolicy_MustSecure = "must_secure"
 	GatewayMacsecPatch_SecurityPolicy_ShouldSecure = "should_secure"
 )
 
@@ -6964,9 +7062,9 @@ func (gatewayMacsecPatch *GatewayMacsecPatch) AsPatch() (_patch map[string]inter
 	return
 }
 
-// GatewayMacsecPrototype : MACsec configuration information of a Direct Link gateway.
+// GatewayMacsecPrototype : MACsec configuration information of a direct link.
 type GatewayMacsecPrototype struct {
-	// Determines if the MACsec feature should initially be active (true) or inactive (false) for a gateway.
+	// Determines if the MACsec feature will initially be active (true) or inactive (false) for a direct link.
 	Active *bool `json:"active" validate:"required"`
 
 	// List of all connectivity association keys (CAKs) to be associated associated with the MACsec feature on a direct
@@ -6982,10 +7080,10 @@ type GatewayMacsecPrototype struct {
 
 	// Determines how packets without MACsec headers are handled.
 	//
-	// `must_secure` - Packets without MACsec headers are dropped. This policy should be used to prefer security over
-	// network availability.
-	// `should_secure` - Packets without MACsec headers are allowed. This policy should be used to prefer network
-	// availability over security.
+	// - `must_secure` - Packets without MACsec headers are dropped. Use this policy to prefer security over network
+	// availability.
+	// - `should_secure` - Packets without MACsec headers are allowed. Use this policy to prefer network availability over
+	// security.
 	SecurityPolicy *string `json:"security_policy" validate:"required"`
 
 	// The window size determines the number of frames in a window for replay protection.
@@ -6998,21 +7096,21 @@ type GatewayMacsecPrototype struct {
 // Constants associated with the GatewayMacsecPrototype.SecurityPolicy property.
 // Determines how packets without MACsec headers are handled.
 //
-// `must_secure` - Packets without MACsec headers are dropped. This policy should be used to prefer security over
-// network availability.
-// `should_secure` - Packets without MACsec headers are allowed. This policy should be used to prefer network
-// availability over security.
+// - `must_secure` - Packets without MACsec headers are dropped. Use this policy to prefer security over network
+// availability.
+// - `should_secure` - Packets without MACsec headers are allowed. Use this policy to prefer network availability over
+// security.
 const (
-	GatewayMacsecPrototype_SecurityPolicy_MustSecure   = "must_secure"
+	GatewayMacsecPrototype_SecurityPolicy_MustSecure = "must_secure"
 	GatewayMacsecPrototype_SecurityPolicy_ShouldSecure = "should_secure"
 )
 
 // NewGatewayMacsecPrototype : Instantiate GatewayMacsecPrototype (Generic Model Constructor)
 func (*DirectLinkV1) NewGatewayMacsecPrototype(active bool, caks []GatewayMacsecCakPrototype, sakRekey SakRekeyPrototypeIntf, securityPolicy string) (_model *GatewayMacsecPrototype, err error) {
 	_model = &GatewayMacsecPrototype{
-		Active:         core.BoolPtr(active),
-		Caks:           caks,
-		SakRekey:       sakRekey,
+		Active: core.BoolPtr(active),
+		Caks: caks,
+		SakRekey: sakRekey,
 		SecurityPolicy: core.StringPtr(securityPolicy),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -7054,17 +7152,17 @@ func UnmarshalGatewayMacsecPrototype(m map[string]json.RawMessage, result interf
 	return
 }
 
-// GatewayMacsecReference : MACsec configuration information of a Direct Link gateway.
+// GatewayMacsecReference : MACsec configuration information of a direct link.
 type GatewayMacsecReference struct {
-	// Indicates if the MACsec feature is currently active (true) or inactive (false) for a gateway.
+	// Indicates if the MACsec feature is currently active (true) or inactive (false) for a direct link.
 	Active *bool `json:"active" validate:"required"`
 
 	// Determines how packets without MACsec headers are handled.
 	//
-	// `must_secure` - Packets without MACsec headers are dropped. This policy should be used to prefer security over
-	// network availability.
-	// `should_secure` - Packets without MACsec headers are allowed. This policy should be used to prefer network
-	// availability over security.
+	// - `must_secure` - Packets without MACsec headers are dropped. Use this policy to prefer security over network
+	// availability.
+	// - `should_secure` - Packets without MACsec headers are allowed. Use this policy to prefer network availability over
+	// security.
 	SecurityPolicy *string `json:"security_policy" validate:"required"`
 
 	// Current status of MACsec on this direct link.
@@ -7084,12 +7182,12 @@ type GatewayMacsecReference struct {
 // Constants associated with the GatewayMacsecReference.SecurityPolicy property.
 // Determines how packets without MACsec headers are handled.
 //
-// `must_secure` - Packets without MACsec headers are dropped. This policy should be used to prefer security over
-// network availability.
-// `should_secure` - Packets without MACsec headers are allowed. This policy should be used to prefer network
-// availability over security.
+// - `must_secure` - Packets without MACsec headers are dropped. Use this policy to prefer security over network
+// availability.
+// - `should_secure` - Packets without MACsec headers are allowed. Use this policy to prefer network availability over
+// security.
 const (
-	GatewayMacsecReference_SecurityPolicy_MustSecure   = "must_secure"
+	GatewayMacsecReference_SecurityPolicy_MustSecure = "must_secure"
 	GatewayMacsecReference_SecurityPolicy_ShouldSecure = "should_secure"
 )
 
@@ -7104,11 +7202,11 @@ const (
 // See `status_reasons[]` for possible remediation of the `failed` `status`.
 const (
 	GatewayMacsecReference_Status_Deleting = "deleting"
-	GatewayMacsecReference_Status_Failed   = "failed"
-	GatewayMacsecReference_Status_Init     = "init"
-	GatewayMacsecReference_Status_Offline  = "offline"
-	GatewayMacsecReference_Status_Pending  = "pending"
-	GatewayMacsecReference_Status_Secured  = "secured"
+	GatewayMacsecReference_Status_Failed = "failed"
+	GatewayMacsecReference_Status_Init = "init"
+	GatewayMacsecReference_Status_Offline = "offline"
+	GatewayMacsecReference_Status_Pending = "pending"
+	GatewayMacsecReference_Status_Secured = "secured"
 )
 
 // UnmarshalGatewayMacsecReference unmarshals an instance of GatewayMacsecReference from the specified map of raw messages.
@@ -7142,8 +7240,8 @@ func UnmarshalGatewayMacsecReference(m map[string]json.RawMessage, result interf
 type GatewayMacsecStatusReason struct {
 	// A reason code for the status:
 	// - `macsec_cak_failed`: At least one of the connectivity association keys (CAKs) associated with the MACsec
-	// configuration was unable to be configured on the direct link gateway. Refer to the `status` of the CAKs associated
-	// with the MACsec configuration to find the the source of this reason.
+	// configuration was unable to be configured on the direct link. Refer to the `status` of the CAKs associated with the
+	// MACsec configuration to find the the source of this reason.
 	Code *string `json:"code" validate:"required"`
 
 	// An explanation of the status reason.
@@ -7156,8 +7254,8 @@ type GatewayMacsecStatusReason struct {
 // Constants associated with the GatewayMacsecStatusReason.Code property.
 // A reason code for the status:
 // - `macsec_cak_failed`: At least one of the connectivity association keys (CAKs) associated with the MACsec
-// configuration was unable to be configured on the direct link gateway. Refer to the `status` of the CAKs associated
-// with the MACsec configuration to find the the source of this reason.
+// configuration was unable to be configured on the direct link. Refer to the `status` of the CAKs associated with the
+// MACsec configuration to find the the source of this reason.
 const (
 	GatewayMacsecStatusReason_Code_MacsecCakFailed = "macsec_cak_failed"
 )
@@ -7269,21 +7367,21 @@ type GatewayPatchTemplate struct {
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GatewayPatchTemplate_ConnectionMode_Direct  = "direct"
+	GatewayPatchTemplate_ConnectionMode_Direct = "direct"
 	GatewayPatchTemplate_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GatewayPatchTemplate.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayPatchTemplate_DefaultExportRouteFilter_Deny   = "deny"
+	GatewayPatchTemplate_DefaultExportRouteFilter_Deny = "deny"
 	GatewayPatchTemplate_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayPatchTemplate.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayPatchTemplate_DefaultImportRouteFilter_Deny   = "deny"
+	GatewayPatchTemplate_DefaultImportRouteFilter_Deny = "deny"
 	GatewayPatchTemplate_DefaultImportRouteFilter_Permit = "permit"
 )
 
@@ -7504,10 +7602,10 @@ type GatewayStatistic struct {
 // Constants associated with the GatewayStatistic.Type property.
 // statistic type.
 const (
-	GatewayStatistic_Type_BfdSession          = "bfd_session"
-	GatewayStatistic_Type_MacsecMkaSession    = "macsec_mka_session"
+	GatewayStatistic_Type_BfdSession = "bfd_session"
+	GatewayStatistic_Type_MacsecMkaSession = "macsec_mka_session"
 	GatewayStatistic_Type_MacsecMkaStatistics = "macsec_mka_statistics"
-	GatewayStatistic_Type_MacsecPolicy        = "macsec_policy"
+	GatewayStatistic_Type_MacsecPolicy = "macsec_policy"
 )
 
 // UnmarshalGatewayStatistic unmarshals an instance of GatewayStatistic from the specified map of raw messages.
@@ -7575,12 +7673,11 @@ const (
 // Constants associated with the GatewayStatus.Value property.
 // Status.
 const (
-	GatewayStatus_Value_Active      = "active"
-	GatewayStatus_Value_Connect     = "connect"
+	GatewayStatus_Value_Active = "active"
+	GatewayStatus_Value_Connect = "connect"
 	GatewayStatus_Value_Established = "established"
-	GatewayStatus_Value_Idle        = "idle"
+	GatewayStatus_Value_Idle = "idle"
 )
-
 func (*GatewayStatus) isaGatewayStatus() bool {
 	return true
 }
@@ -7771,15 +7868,15 @@ type GatewayTemplate struct {
 	// Gateway location.
 	LocationName *string `json:"location_name,omitempty"`
 
-	// MACsec configuration information of a Direct Link gateway.
+	// MACsec configuration information of a direct link.
 	Macsec *GatewayMacsecPrototype `json:"macsec,omitempty"`
 
 	// Indicates the direct link's MACsec capability. It must match one of the MACsec related `capabilities` of the
 	// `cross_connect_router`.
 	//
-	// - non_macsec: The direct link does not support MACsec.
-	// - macsec: The direct link supports MACsec. The MACsec feature must be enabled.
-	// - macsec_optional: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
+	// - `non_macsec`: The direct link does not support MACsec.
+	// - `macsec`: The direct link supports MACsec. The MACsec feature must be enabled.
+	// - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 	// direct link creation.
 	//
 	// If not explicitly provided, the field will be assigned with the following priorities based on `cross_connect_router`
@@ -7804,28 +7901,28 @@ type GatewayTemplate struct {
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GatewayTemplate_ConnectionMode_Direct  = "direct"
+	GatewayTemplate_ConnectionMode_Direct = "direct"
 	GatewayTemplate_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GatewayTemplate.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayTemplate_DefaultExportRouteFilter_Deny   = "deny"
+	GatewayTemplate_DefaultExportRouteFilter_Deny = "deny"
 	GatewayTemplate_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayTemplate.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayTemplate_DefaultImportRouteFilter_Deny   = "deny"
+	GatewayTemplate_DefaultImportRouteFilter_Deny = "deny"
 	GatewayTemplate_DefaultImportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayTemplate.Type property.
 // Offering type.
 const (
-	GatewayTemplate_Type_Connect   = "connect"
+	GatewayTemplate_Type_Connect = "connect"
 	GatewayTemplate_Type_Dedicated = "dedicated"
 )
 
@@ -7833,25 +7930,24 @@ const (
 // Indicates the direct link's MACsec capability. It must match one of the MACsec related `capabilities` of the
 // `cross_connect_router`.
 //
-// - non_macsec: The direct link does not support MACsec.
-// - macsec: The direct link supports MACsec. The MACsec feature must be enabled.
-// - macsec_optional: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
+// - `non_macsec`: The direct link does not support MACsec.
+// - `macsec`: The direct link supports MACsec. The MACsec feature must be enabled.
+// - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 // direct link creation.
 //
 // If not explicitly provided, the field will be assigned with the following priorities based on `cross_connect_router`
 // capabilities and available ports:
 //   - `macsec` was not provided in the request
-//   - `non_macsec`
-//   - `macsec_optional`
+//     - `non_macsec`
+//     - `macsec_optional`
 //   - `macsec` was provided in the request
-//   - `macsec_optional`
-//   - `macsec`.
+//     - `macsec_optional`
+//     - `macsec`.
 const (
-	GatewayTemplate_MacsecCapability_Macsec         = "macsec"
+	GatewayTemplate_MacsecCapability_Macsec = "macsec"
 	GatewayTemplate_MacsecCapability_MacsecOptional = "macsec_optional"
-	GatewayTemplate_MacsecCapability_NonMacsec      = "non_macsec"
+	GatewayTemplate_MacsecCapability_NonMacsec = "non_macsec"
 )
-
 func (*GatewayTemplate) isaGatewayTemplate() bool {
 	return true
 }
@@ -8020,7 +8116,7 @@ type GatewayTemplateRouteFilter struct {
 // Constants associated with the GatewayTemplateRouteFilter.Action property.
 // Determines whether routes that match the prefix-set will be allowed (permit) or rejected (deny) through the filter.
 const (
-	GatewayTemplateRouteFilter_Action_Deny   = "deny"
+	GatewayTemplateRouteFilter_Action_Deny = "deny"
 	GatewayTemplateRouteFilter_Action_Permit = "permit"
 )
 
@@ -8103,14 +8199,14 @@ type GatewayVirtualConnection struct {
 // The list of enumerated values for this property may expand in the future. Code and processes using this field  must
 // tolerate unexpected values.
 const (
-	GatewayVirtualConnection_Status_ApprovalPending          = "approval_pending"
-	GatewayVirtualConnection_Status_Attached                 = "attached"
-	GatewayVirtualConnection_Status_Deleting                 = "deleting"
-	GatewayVirtualConnection_Status_DetachedByNetwork        = "detached_by_network"
+	GatewayVirtualConnection_Status_ApprovalPending = "approval_pending"
+	GatewayVirtualConnection_Status_Attached = "attached"
+	GatewayVirtualConnection_Status_Deleting = "deleting"
+	GatewayVirtualConnection_Status_DetachedByNetwork = "detached_by_network"
 	GatewayVirtualConnection_Status_DetachedByNetworkPending = "detached_by_network_pending"
-	GatewayVirtualConnection_Status_Expired                  = "expired"
-	GatewayVirtualConnection_Status_Pending                  = "pending"
-	GatewayVirtualConnection_Status_Rejected                 = "rejected"
+	GatewayVirtualConnection_Status_Expired = "expired"
+	GatewayVirtualConnection_Status_Pending = "pending"
+	GatewayVirtualConnection_Status_Rejected = "rejected"
 )
 
 // Constants associated with the GatewayVirtualConnection.Type property.
@@ -8121,7 +8217,7 @@ const (
 const (
 	GatewayVirtualConnection_Type_Classic = "classic"
 	GatewayVirtualConnection_Type_Transit = "transit"
-	GatewayVirtualConnection_Type_Vpc     = "vpc"
+	GatewayVirtualConnection_Type_Vpc = "vpc"
 )
 
 // UnmarshalGatewayVirtualConnection unmarshals an instance of GatewayVirtualConnection from the specified map of raw messages.
@@ -8251,7 +8347,7 @@ type GetGatewayExportRouteFilterOptions struct {
 func (*DirectLinkV1) NewGetGatewayExportRouteFilterOptions(gatewayID string, id string) *GetGatewayExportRouteFilterOptions {
 	return &GetGatewayExportRouteFilterOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID:        core.StringPtr(id),
+		ID: core.StringPtr(id),
 	}
 }
 
@@ -8289,7 +8385,7 @@ type GetGatewayImportRouteFilterOptions struct {
 func (*DirectLinkV1) NewGetGatewayImportRouteFilterOptions(gatewayID string, id string) *GetGatewayImportRouteFilterOptions {
 	return &GetGatewayImportRouteFilterOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID:        core.StringPtr(id),
+		ID: core.StringPtr(id),
 	}
 }
 
@@ -8326,7 +8422,7 @@ type GetGatewayMacsecCakOptions struct {
 // NewGetGatewayMacsecCakOptions : Instantiate GetGatewayMacsecCakOptions
 func (*DirectLinkV1) NewGetGatewayMacsecCakOptions(id string, cakID string) *GetGatewayMacsecCakOptions {
 	return &GetGatewayMacsecCakOptions{
-		ID:    core.StringPtr(id),
+		ID: core.StringPtr(id),
 		CakID: core.StringPtr(cakID),
 	}
 }
@@ -8498,7 +8594,7 @@ type GetGatewayResponse struct {
 	// Gateway location.
 	LocationName *string `json:"location_name,omitempty"`
 
-	// MACsec configuration information of a Direct Link gateway.
+	// MACsec configuration information of a direct link.
 	Macsec *GatewayMacsecReference `json:"macsec,omitempty"`
 
 	// Indicates the direct link's MACsec capability. It must match one of the MACsec related `capabilities` of the
@@ -8506,9 +8602,9 @@ type GetGatewayResponse struct {
 	//
 	// Only included on type=dedicated direct links.
 	//
-	// - non_macsec: The direct link does not support MACsec.
-	// - macsec: The direct link supports MACsec. The MACsec feature must be enabled.
-	// - macsec_optional: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
+	// - `non_macsec`: The direct link does not support MACsec.
+	// - `macsec`: The direct link supports MACsec. The MACsec feature must be enabled.
+	// - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 	// direct link creation.
 	MacsecCapability *string `json:"macsec_capability,omitempty"`
 
@@ -8556,10 +8652,10 @@ type GetGatewayResponse struct {
 // Gateway BGP status. The list of enumerated values for this property may expand in the future. Code and processes
 // using this field  must tolerate unexpected values.
 const (
-	GetGatewayResponse_BgpStatus_Active      = "active"
-	GetGatewayResponse_BgpStatus_Connect     = "connect"
+	GetGatewayResponse_BgpStatus_Active = "active"
+	GetGatewayResponse_BgpStatus_Connect = "connect"
 	GetGatewayResponse_BgpStatus_Established = "established"
-	GetGatewayResponse_BgpStatus_Idle        = "idle"
+	GetGatewayResponse_BgpStatus_Idle = "idle"
 )
 
 // Constants associated with the GetGatewayResponse.ConnectionMode property.
@@ -8567,21 +8663,21 @@ const (
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GetGatewayResponse_ConnectionMode_Direct  = "direct"
+	GetGatewayResponse_ConnectionMode_Direct = "direct"
 	GetGatewayResponse_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GetGatewayResponse.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GetGatewayResponse_DefaultExportRouteFilter_Deny   = "deny"
+	GetGatewayResponse_DefaultExportRouteFilter_Deny = "deny"
 	GetGatewayResponse_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GetGatewayResponse.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GetGatewayResponse_DefaultImportRouteFilter_Deny   = "deny"
+	GetGatewayResponse_DefaultImportRouteFilter_Deny = "deny"
 	GetGatewayResponse_DefaultImportRouteFilter_Permit = "permit"
 )
 
@@ -8590,7 +8686,7 @@ const (
 // expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
 	GetGatewayResponse_LinkStatus_Down = "down"
-	GetGatewayResponse_LinkStatus_Up   = "up"
+	GetGatewayResponse_LinkStatus_Up = "up"
 )
 
 // Constants associated with the GetGatewayResponse.MacsecCapability property.
@@ -8599,14 +8695,14 @@ const (
 //
 // Only included on type=dedicated direct links.
 //
-// - non_macsec: The direct link does not support MACsec.
-// - macsec: The direct link supports MACsec. The MACsec feature must be enabled.
-// - macsec_optional: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
+// - `non_macsec`: The direct link does not support MACsec.
+// - `macsec`: The direct link supports MACsec. The MACsec feature must be enabled.
+// - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 // direct link creation.
 const (
-	GetGatewayResponse_MacsecCapability_Macsec         = "macsec"
+	GetGatewayResponse_MacsecCapability_Macsec = "macsec"
 	GetGatewayResponse_MacsecCapability_MacsecOptional = "macsec_optional"
-	GetGatewayResponse_MacsecCapability_NonMacsec      = "non_macsec"
+	GetGatewayResponse_MacsecCapability_NonMacsec = "non_macsec"
 )
 
 // Constants associated with the GetGatewayResponse.OperationalStatus property.
@@ -8616,29 +8712,28 @@ const (
 // See `operational_status_reasons[]` for possible remediation of the `failed` `operational_status`.
 const (
 	GetGatewayResponse_OperationalStatus_AwaitingCompletionNotice = "awaiting_completion_notice"
-	GetGatewayResponse_OperationalStatus_AwaitingLoa              = "awaiting_loa"
+	GetGatewayResponse_OperationalStatus_AwaitingLoa = "awaiting_loa"
 	GetGatewayResponse_OperationalStatus_CompletionNoticeApproved = "completion_notice_approved"
 	GetGatewayResponse_OperationalStatus_CompletionNoticeReceived = "completion_notice_received"
 	GetGatewayResponse_OperationalStatus_CompletionNoticeRejected = "completion_notice_rejected"
-	GetGatewayResponse_OperationalStatus_Configuring              = "configuring"
-	GetGatewayResponse_OperationalStatus_CreatePending            = "create_pending"
-	GetGatewayResponse_OperationalStatus_CreateRejected           = "create_rejected"
-	GetGatewayResponse_OperationalStatus_DeletePending            = "delete_pending"
-	GetGatewayResponse_OperationalStatus_Failed                   = "failed"
-	GetGatewayResponse_OperationalStatus_LoaAccepted              = "loa_accepted"
-	GetGatewayResponse_OperationalStatus_LoaCreated               = "loa_created"
-	GetGatewayResponse_OperationalStatus_LoaRejected              = "loa_rejected"
-	GetGatewayResponse_OperationalStatus_Provisioned              = "provisioned"
+	GetGatewayResponse_OperationalStatus_Configuring = "configuring"
+	GetGatewayResponse_OperationalStatus_CreatePending = "create_pending"
+	GetGatewayResponse_OperationalStatus_CreateRejected = "create_rejected"
+	GetGatewayResponse_OperationalStatus_DeletePending = "delete_pending"
+	GetGatewayResponse_OperationalStatus_Failed = "failed"
+	GetGatewayResponse_OperationalStatus_LoaAccepted = "loa_accepted"
+	GetGatewayResponse_OperationalStatus_LoaCreated = "loa_created"
+	GetGatewayResponse_OperationalStatus_LoaRejected = "loa_rejected"
+	GetGatewayResponse_OperationalStatus_Provisioned = "provisioned"
 )
 
 // Constants associated with the GetGatewayResponse.Type property.
 // Offering type. The list of enumerated values for this property may expand in the future. Code and processes using
 // this field  must tolerate unexpected values.
 const (
-	GetGatewayResponse_Type_Connect   = "connect"
+	GetGatewayResponse_Type_Connect = "connect"
 	GetGatewayResponse_Type_Dedicated = "dedicated"
 )
-
 func (*GetGatewayResponse) isaGetGatewayResponse() bool {
 	return true
 }
@@ -8870,7 +8965,7 @@ type GetGatewayRouteReportOptions struct {
 func (*DirectLinkV1) NewGetGatewayRouteReportOptions(gatewayID string, id string) *GetGatewayRouteReportOptions {
 	return &GetGatewayRouteReportOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID:        core.StringPtr(id),
+		ID: core.StringPtr(id),
 	}
 }
 
@@ -8907,16 +9002,16 @@ type GetGatewayStatisticsOptions struct {
 // Constants associated with the GetGatewayStatisticsOptions.Type property.
 // Specify statistic to retrieve.
 const (
-	GetGatewayStatisticsOptions_Type_BfdSession          = "bfd_session"
-	GetGatewayStatisticsOptions_Type_MacsecMkaSession    = "macsec_mka_session"
+	GetGatewayStatisticsOptions_Type_BfdSession = "bfd_session"
+	GetGatewayStatisticsOptions_Type_MacsecMkaSession = "macsec_mka_session"
 	GetGatewayStatisticsOptions_Type_MacsecMkaStatistics = "macsec_mka_statistics"
-	GetGatewayStatisticsOptions_Type_MacsecPolicy        = "macsec_policy"
+	GetGatewayStatisticsOptions_Type_MacsecPolicy = "macsec_policy"
 )
 
 // NewGetGatewayStatisticsOptions : Instantiate GetGatewayStatisticsOptions
 func (*DirectLinkV1) NewGetGatewayStatisticsOptions(id string, typeVar string) *GetGatewayStatisticsOptions {
 	return &GetGatewayStatisticsOptions{
-		ID:   core.StringPtr(id),
+		ID: core.StringPtr(id),
 		Type: core.StringPtr(typeVar),
 	}
 }
@@ -8954,8 +9049,8 @@ type GetGatewayStatusOptions struct {
 // Constants associated with the GetGatewayStatusOptions.Type property.
 // Specify status to retrieve.
 const (
-	GetGatewayStatusOptions_Type_Bfd  = "bfd"
-	GetGatewayStatusOptions_Type_Bgp  = "bgp"
+	GetGatewayStatusOptions_Type_Bfd = "bfd"
+	GetGatewayStatusOptions_Type_Bgp = "bgp"
 	GetGatewayStatusOptions_Type_Link = "link"
 )
 
@@ -9000,7 +9095,7 @@ type GetGatewayVirtualConnectionOptions struct {
 func (*DirectLinkV1) NewGetGatewayVirtualConnectionOptions(gatewayID string, id string) *GetGatewayVirtualConnectionOptions {
 	return &GetGatewayVirtualConnectionOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID:        core.StringPtr(id),
+		ID: core.StringPtr(id),
 	}
 }
 
@@ -9048,65 +9143,6 @@ func (_options *GetPortOptions) SetID(id string) *GetPortOptions {
 func (options *GetPortOptions) SetHeaders(param map[string]string) *GetPortOptions {
 	options.Headers = param
 	return options
-}
-
-// HpcsKeyIdentity : A [Hyper Protect Crypto Service Standard Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started).
-type HpcsKeyIdentity struct {
-	// The CRN of the key.
-	Crn *string `json:"crn" validate:"required"`
-}
-
-// NewHpcsKeyIdentity : Instantiate HpcsKeyIdentity (Generic Model Constructor)
-func (*DirectLinkV1) NewHpcsKeyIdentity(crn string) (_model *HpcsKeyIdentity, err error) {
-	_model = &HpcsKeyIdentity{
-		Crn: core.StringPtr(crn),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	if err != nil {
-		err = core.SDKErrorf(err, "", "model-missing-required", common.GetComponentInfo())
-	}
-	return
-}
-
-// UnmarshalHpcsKeyIdentity unmarshals an instance of HpcsKeyIdentity from the specified map of raw messages.
-func UnmarshalHpcsKeyIdentity(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(HpcsKeyIdentity)
-	err = core.UnmarshalPrimitive(m, "crn", &obj.Crn)
-	if err != nil {
-		err = core.SDKErrorf(err, "", "crn-error", common.GetComponentInfo())
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// asPatch returns a generic map representation of the HpcsKeyIdentity
-func (hpcsKeyIdentity *HpcsKeyIdentity) asPatch() (_patch map[string]interface{}) {
-	_patch = map[string]interface{}{}
-	if !core.IsNil(hpcsKeyIdentity.Crn) {
-		_patch["crn"] = hpcsKeyIdentity.Crn
-	}
-
-	return
-}
-
-// HpcsKeyReference : A reference to a [Hyper Protect Crypto Service Standard
-// Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started).
-type HpcsKeyReference struct {
-	// The CRN of the referenced key.
-	Crn *string `json:"crn" validate:"required"`
-}
-
-// UnmarshalHpcsKeyReference unmarshals an instance of HpcsKeyReference from the specified map of raw messages.
-func UnmarshalHpcsKeyReference(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(HpcsKeyReference)
-	err = core.UnmarshalPrimitive(m, "crn", &obj.Crn)
-	if err != nil {
-		err = core.SDKErrorf(err, "", "crn-error", common.GetComponentInfo())
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
 }
 
 // ImportRouteFilterCollection : Collection of import route filters.
@@ -9384,7 +9420,7 @@ type ListOfferingTypeLocationCrossConnectRoutersOptions struct {
 // Constants associated with the ListOfferingTypeLocationCrossConnectRoutersOptions.OfferingType property.
 // The Direct Link offering type.  Current supported values are `"dedicated"` and `"connect"`.
 const (
-	ListOfferingTypeLocationCrossConnectRoutersOptions_OfferingType_Connect   = "connect"
+	ListOfferingTypeLocationCrossConnectRoutersOptions_OfferingType_Connect = "connect"
 	ListOfferingTypeLocationCrossConnectRoutersOptions_OfferingType_Dedicated = "dedicated"
 )
 
@@ -9426,7 +9462,7 @@ type ListOfferingTypeLocationsOptions struct {
 // Constants associated with the ListOfferingTypeLocationsOptions.OfferingType property.
 // The Direct Link offering type.  Current supported values are `"dedicated"` and `"connect"`.
 const (
-	ListOfferingTypeLocationsOptions_OfferingType_Connect   = "connect"
+	ListOfferingTypeLocationsOptions_OfferingType_Connect = "connect"
 	ListOfferingTypeLocationsOptions_OfferingType_Dedicated = "dedicated"
 )
 
@@ -9461,7 +9497,7 @@ type ListOfferingTypeSpeedsOptions struct {
 // Constants associated with the ListOfferingTypeSpeedsOptions.OfferingType property.
 // The Direct Link offering type.  Current supported values are `"dedicated"` and `"connect"`.
 const (
-	ListOfferingTypeSpeedsOptions_OfferingType_Connect   = "connect"
+	ListOfferingTypeSpeedsOptions_OfferingType_Connect = "connect"
 	ListOfferingTypeSpeedsOptions_OfferingType_Dedicated = "dedicated"
 )
 
@@ -9578,8 +9614,7 @@ type LocationOutput struct {
 	// Location type.
 	LocationType *string `json:"location_type" validate:"required"`
 
-	// Indicate whether location supports MACsec.  Only returned for gateway type=dedicated locations.  Contact IBM support
-	// for access to MACsec.
+	// Indicate whether location supports MACsec.  Only returned for direct link type=dedicated locations.
 	MacsecEnabled *bool `json:"macsec_enabled,omitempty"`
 
 	// Location market.
@@ -9679,8 +9714,7 @@ type OfferingSpeed struct {
 	// Link speed in megabits per second.
 	LinkSpeed *int64 `json:"link_speed" validate:"required"`
 
-	// Indicate whether speed supports MACsec.  Only returned for gateway type=dedicated speeds.  Contact IBM support for
-	// access to MACsec.
+	// Indicate whether speed supports MACsec.  Only returned for gateway type=dedicated speeds.
 	MacsecEnabled *bool `json:"macsec_enabled,omitempty"`
 }
 
@@ -9911,7 +9945,7 @@ type ReplaceGatewayAsPrependsOptions struct {
 func (*DirectLinkV1) NewReplaceGatewayAsPrependsOptions(gatewayID string, ifMatch string) *ReplaceGatewayAsPrependsOptions {
 	return &ReplaceGatewayAsPrependsOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		IfMatch:   core.StringPtr(ifMatch),
+		IfMatch: core.StringPtr(ifMatch),
 	}
 }
 
@@ -9959,7 +9993,7 @@ type ReplaceGatewayExportRouteFiltersOptions struct {
 func (*DirectLinkV1) NewReplaceGatewayExportRouteFiltersOptions(gatewayID string, ifMatch string) *ReplaceGatewayExportRouteFiltersOptions {
 	return &ReplaceGatewayExportRouteFiltersOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		IfMatch:   core.StringPtr(ifMatch),
+		IfMatch: core.StringPtr(ifMatch),
 	}
 }
 
@@ -10007,7 +10041,7 @@ type ReplaceGatewayImportRouteFiltersOptions struct {
 func (*DirectLinkV1) NewReplaceGatewayImportRouteFiltersOptions(gatewayID string, ifMatch string) *ReplaceGatewayImportRouteFiltersOptions {
 	return &ReplaceGatewayImportRouteFiltersOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		IfMatch:   core.StringPtr(ifMatch),
+		IfMatch: core.StringPtr(ifMatch),
 	}
 }
 
@@ -10122,7 +10156,7 @@ type RouteFilter struct {
 // Constants associated with the RouteFilter.Action property.
 // Determines whether routes that match the prefix-set will be allowed (permit) or rejected (deny) through the filter.
 const (
-	RouteFilter_Action_Deny   = "deny"
+	RouteFilter_Action_Deny = "deny"
 	RouteFilter_Action_Permit = "permit"
 )
 
@@ -10210,7 +10244,7 @@ type RouteReport struct {
 // using this field must tolerate unexpected values.
 const (
 	RouteReport_Status_Complete = "complete"
-	RouteReport_Status_Pending  = "pending"
+	RouteReport_Status_Pending = "pending"
 )
 
 // UnmarshalRouteReport unmarshals an instance of RouteReport from the specified map of raw messages.
@@ -10405,7 +10439,6 @@ type RouteReportOverlappingRoute struct {
 const (
 	RouteReportOverlappingRoute_Type_VirtualConnection = "virtual_connection"
 )
-
 func (*RouteReportOverlappingRoute) isaRouteReportOverlappingRoute() bool {
 	return true
 }
@@ -10523,7 +10556,6 @@ type SakRekey struct {
 const (
 	SakRekey_Mode_Timer = "timer"
 )
-
 func (*SakRekey) isaSakRekey() bool {
 	return true
 }
@@ -10566,7 +10598,6 @@ type SakRekeyPatch struct {
 const (
 	SakRekeyPatch_Mode_Timer = "timer"
 )
-
 func (*SakRekeyPatch) isaSakRekeyPatch() bool {
 	return true
 }
@@ -10623,7 +10654,6 @@ type SakRekeyPrototype struct {
 const (
 	SakRekeyPrototype_Mode_Timer = "timer"
 )
-
 func (*SakRekeyPrototype) isaSakRekeyPrototype() bool {
 	return true
 }
@@ -10654,7 +10684,7 @@ type SetGatewayMacsecOptions struct {
 	// Direct Link gateway identifier.
 	ID *string `json:"id" validate:"required,ne="`
 
-	// Determines if the MACsec feature should initially be active (true) or inactive (false) for a gateway.
+	// Determines if the MACsec feature will initially be active (true) or inactive (false) for a direct link.
 	Active *bool `json:"active" validate:"required"`
 
 	// List of all connectivity association keys (CAKs) to be associated associated with the MACsec feature on a direct
@@ -10670,10 +10700,10 @@ type SetGatewayMacsecOptions struct {
 
 	// Determines how packets without MACsec headers are handled.
 	//
-	// `must_secure` - Packets without MACsec headers are dropped. This policy should be used to prefer security over
-	// network availability.
-	// `should_secure` - Packets without MACsec headers are allowed. This policy should be used to prefer network
-	// availability over security.
+	// - `must_secure` - Packets without MACsec headers are dropped. Use this policy to prefer security over network
+	// availability.
+	// - `should_secure` - Packets without MACsec headers are allowed. Use this policy to prefer network availability over
+	// security.
 	SecurityPolicy *string `json:"security_policy" validate:"required"`
 
 	// The window size determines the number of frames in a window for replay protection.
@@ -10694,22 +10724,22 @@ type SetGatewayMacsecOptions struct {
 // Constants associated with the SetGatewayMacsecOptions.SecurityPolicy property.
 // Determines how packets without MACsec headers are handled.
 //
-// `must_secure` - Packets without MACsec headers are dropped. This policy should be used to prefer security over
-// network availability.
-// `should_secure` - Packets without MACsec headers are allowed. This policy should be used to prefer network
-// availability over security.
+// - `must_secure` - Packets without MACsec headers are dropped. Use this policy to prefer security over network
+// availability.
+// - `should_secure` - Packets without MACsec headers are allowed. Use this policy to prefer network availability over
+// security.
 const (
-	SetGatewayMacsecOptions_SecurityPolicy_MustSecure   = "must_secure"
+	SetGatewayMacsecOptions_SecurityPolicy_MustSecure = "must_secure"
 	SetGatewayMacsecOptions_SecurityPolicy_ShouldSecure = "should_secure"
 )
 
 // NewSetGatewayMacsecOptions : Instantiate SetGatewayMacsecOptions
 func (*DirectLinkV1) NewSetGatewayMacsecOptions(id string, active bool, caks []GatewayMacsecCakPrototype, sakRekey SakRekeyPrototypeIntf, securityPolicy string) *SetGatewayMacsecOptions {
 	return &SetGatewayMacsecOptions{
-		ID:             core.StringPtr(id),
-		Active:         core.BoolPtr(active),
-		Caks:           caks,
-		SakRekey:       sakRekey,
+		ID: core.StringPtr(id),
+		Active: core.BoolPtr(active),
+		Caks: caks,
+		SakRekey: sakRekey,
 		SecurityPolicy: core.StringPtr(securityPolicy),
 	}
 }
@@ -10808,8 +10838,8 @@ type UpdateGatewayExportRouteFilterOptions struct {
 // NewUpdateGatewayExportRouteFilterOptions : Instantiate UpdateGatewayExportRouteFilterOptions
 func (*DirectLinkV1) NewUpdateGatewayExportRouteFilterOptions(gatewayID string, id string, updateRouteFilterTemplatePatch map[string]interface{}) *UpdateGatewayExportRouteFilterOptions {
 	return &UpdateGatewayExportRouteFilterOptions{
-		GatewayID:                      core.StringPtr(gatewayID),
-		ID:                             core.StringPtr(id),
+		GatewayID: core.StringPtr(gatewayID),
+		ID: core.StringPtr(id),
 		UpdateRouteFilterTemplatePatch: updateRouteFilterTemplatePatch,
 	}
 }
@@ -10856,8 +10886,8 @@ type UpdateGatewayImportRouteFilterOptions struct {
 // NewUpdateGatewayImportRouteFilterOptions : Instantiate UpdateGatewayImportRouteFilterOptions
 func (*DirectLinkV1) NewUpdateGatewayImportRouteFilterOptions(gatewayID string, id string, updateRouteFilterTemplatePatch map[string]interface{}) *UpdateGatewayImportRouteFilterOptions {
 	return &UpdateGatewayImportRouteFilterOptions{
-		GatewayID:                      core.StringPtr(gatewayID),
-		ID:                             core.StringPtr(id),
+		GatewayID: core.StringPtr(gatewayID),
+		ID: core.StringPtr(id),
 		UpdateRouteFilterTemplatePatch: updateRouteFilterTemplatePatch,
 	}
 }
@@ -10904,8 +10934,8 @@ type UpdateGatewayMacsecCakOptions struct {
 // NewUpdateGatewayMacsecCakOptions : Instantiate UpdateGatewayMacsecCakOptions
 func (*DirectLinkV1) NewUpdateGatewayMacsecCakOptions(id string, cakID string, gatewayMacsecCakPatch map[string]interface{}) *UpdateGatewayMacsecCakOptions {
 	return &UpdateGatewayMacsecCakOptions{
-		ID:                    core.StringPtr(id),
-		CakID:                 core.StringPtr(cakID),
+		ID: core.StringPtr(id),
+		CakID: core.StringPtr(cakID),
 		GatewayMacsecCakPatch: gatewayMacsecCakPatch,
 	}
 }
@@ -10949,7 +10979,7 @@ type UpdateGatewayMacsecOptions struct {
 // NewUpdateGatewayMacsecOptions : Instantiate UpdateGatewayMacsecOptions
 func (*DirectLinkV1) NewUpdateGatewayMacsecOptions(id string, gatewayMacsecPatch map[string]interface{}) *UpdateGatewayMacsecOptions {
 	return &UpdateGatewayMacsecOptions{
-		ID:                 core.StringPtr(id),
+		ID: core.StringPtr(id),
 		GatewayMacsecPatch: gatewayMacsecPatch,
 	}
 }
@@ -10987,7 +11017,7 @@ type UpdateGatewayOptions struct {
 // NewUpdateGatewayOptions : Instantiate UpdateGatewayOptions
 func (*DirectLinkV1) NewUpdateGatewayOptions(id string, gatewayPatchTemplatePatch map[string]interface{}) *UpdateGatewayOptions {
 	return &UpdateGatewayOptions{
-		ID:                        core.StringPtr(id),
+		ID: core.StringPtr(id),
 		GatewayPatchTemplatePatch: gatewayPatchTemplatePatch,
 	}
 }
@@ -11029,7 +11059,7 @@ type UpdateGatewayVirtualConnectionOptions struct {
 func (*DirectLinkV1) NewUpdateGatewayVirtualConnectionOptions(gatewayID string, id string, gatewayVirtualConnectionPatchTemplatePatch map[string]interface{}) *UpdateGatewayVirtualConnectionOptions {
 	return &UpdateGatewayVirtualConnectionOptions{
 		GatewayID: core.StringPtr(gatewayID),
-		ID:        core.StringPtr(id),
+		ID: core.StringPtr(id),
 		GatewayVirtualConnectionPatchTemplatePatch: gatewayVirtualConnectionPatchTemplatePatch,
 	}
 }
@@ -11091,7 +11121,7 @@ type UpdateRouteFilterTemplate struct {
 // Constants associated with the UpdateRouteFilterTemplate.Action property.
 // Determines whether routes that match the prefix-set will be allowed (permit) or rejected (deny) through the filter.
 const (
-	UpdateRouteFilterTemplate_Action_Deny   = "deny"
+	UpdateRouteFilterTemplate_Action_Deny = "deny"
 	UpdateRouteFilterTemplate_Action_Permit = "permit"
 )
 
@@ -11239,6 +11269,52 @@ func (authenticationKeyIdentityKeyProtectAuthenticationKeyIdentity *Authenticati
 	return
 }
 
+// AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity : A [Secrets Manager Arbitrary
+// Secret](https://cloud.ibm.com/docs/secrets-manager?topic=secrets-manager-getting-started).
+// This model "extends" AuthenticationKeyIdentity
+type AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity struct {
+	// The CRN of the secret.
+	Crn *string `json:"crn" validate:"required"`
+}
+
+// NewAuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity : Instantiate AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity (Generic Model Constructor)
+func (*DirectLinkV1) NewAuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity(crn string) (_model *AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity, err error) {
+	_model = &AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity{
+		Crn: core.StringPtr(crn),
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "model-missing-required", common.GetComponentInfo())
+	}
+	return
+}
+
+func (*AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity) isaAuthenticationKeyIdentity() bool {
+	return true
+}
+
+// UnmarshalAuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity unmarshals an instance of AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity from the specified map of raw messages.
+func UnmarshalAuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity)
+	err = core.UnmarshalPrimitive(m, "crn", &obj.Crn)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "crn-error", common.GetComponentInfo())
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// asPatch returns a generic map representation of the AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity
+func (authenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity *AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity) asPatch() (_patch map[string]interface{}) {
+	_patch = map[string]interface{}{}
+	if !core.IsNil(authenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity.Crn) {
+		_patch["crn"] = authenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity.Crn
+	}
+
+	return
+}
+
 // AuthenticationKeyReferenceHpcsAuthenticationKeyReference : A reference to a [Hyper Protect Crypto Service Standard
 // Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started).
 // This model "extends" AuthenticationKeyReference
@@ -11278,6 +11354,30 @@ func (*AuthenticationKeyReferenceKeyProtectAuthenticationKeyReference) isaAuthen
 // UnmarshalAuthenticationKeyReferenceKeyProtectAuthenticationKeyReference unmarshals an instance of AuthenticationKeyReferenceKeyProtectAuthenticationKeyReference from the specified map of raw messages.
 func UnmarshalAuthenticationKeyReferenceKeyProtectAuthenticationKeyReference(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(AuthenticationKeyReferenceKeyProtectAuthenticationKeyReference)
+	err = core.UnmarshalPrimitive(m, "crn", &obj.Crn)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "crn-error", common.GetComponentInfo())
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference : A reference to a [Secrets Manager Arbitrary
+// Secret](https://cloud.ibm.com/docs/secrets-manager?topic=secrets-manager-getting-started).
+// This model "extends" AuthenticationKeyReference
+type AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference struct {
+	// The CRN of the referenced key.
+	Crn *string `json:"crn" validate:"required"`
+}
+
+func (*AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference) isaAuthenticationKeyReference() bool {
+	return true
+}
+
+// UnmarshalAuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference unmarshals an instance of AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference from the specified map of raw messages.
+func UnmarshalAuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference)
 	err = core.UnmarshalPrimitive(m, "crn", &obj.Crn)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "crn-error", common.GetComponentInfo())
@@ -11798,10 +11898,10 @@ type GatewayCollectionGatewaysItemCrossAccountGateway struct {
 // Gateway BGP status. The list of enumerated values for this property may expand in the future. Code and processes
 // using this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItemCrossAccountGateway_BgpStatus_Active      = "active"
-	GatewayCollectionGatewaysItemCrossAccountGateway_BgpStatus_Connect     = "connect"
+	GatewayCollectionGatewaysItemCrossAccountGateway_BgpStatus_Active = "active"
+	GatewayCollectionGatewaysItemCrossAccountGateway_BgpStatus_Connect = "connect"
 	GatewayCollectionGatewaysItemCrossAccountGateway_BgpStatus_Established = "established"
-	GatewayCollectionGatewaysItemCrossAccountGateway_BgpStatus_Idle        = "idle"
+	GatewayCollectionGatewaysItemCrossAccountGateway_BgpStatus_Idle = "idle"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemCrossAccountGateway.ConnectionMode property.
@@ -11809,7 +11909,7 @@ const (
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItemCrossAccountGateway_ConnectionMode_Direct  = "direct"
+	GatewayCollectionGatewaysItemCrossAccountGateway_ConnectionMode_Direct = "direct"
 	GatewayCollectionGatewaysItemCrossAccountGateway_ConnectionMode_Transit = "transit"
 )
 
@@ -11818,7 +11918,7 @@ const (
 // expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
 	GatewayCollectionGatewaysItemCrossAccountGateway_LinkStatus_Down = "down"
-	GatewayCollectionGatewaysItemCrossAccountGateway_LinkStatus_Up   = "up"
+	GatewayCollectionGatewaysItemCrossAccountGateway_LinkStatus_Up = "up"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemCrossAccountGateway.OperationalStatus property.
@@ -11826,25 +11926,25 @@ const (
 // processes using this field  must tolerate unexpected values.
 const (
 	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_AwaitingCompletionNotice = "awaiting_completion_notice"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_AwaitingLoa              = "awaiting_loa"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_AwaitingLoa = "awaiting_loa"
 	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_CompletionNoticeApproved = "completion_notice_approved"
 	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_CompletionNoticeReceived = "completion_notice_received"
 	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_CompletionNoticeRejected = "completion_notice_rejected"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_Configuring              = "configuring"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_CreatePending            = "create_pending"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_CreateRejected           = "create_rejected"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_DeletePending            = "delete_pending"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_LoaAccepted              = "loa_accepted"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_LoaCreated               = "loa_created"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_LoaRejected              = "loa_rejected"
-	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_Provisioned              = "provisioned"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_Configuring = "configuring"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_CreatePending = "create_pending"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_CreateRejected = "create_rejected"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_DeletePending = "delete_pending"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_LoaAccepted = "loa_accepted"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_LoaCreated = "loa_created"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_LoaRejected = "loa_rejected"
+	GatewayCollectionGatewaysItemCrossAccountGateway_OperationalStatus_Provisioned = "provisioned"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemCrossAccountGateway.Type property.
 // Offering type. The list of enumerated values for this property may expand in the future. Code and processes using
 // this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItemCrossAccountGateway_Type_Connect   = "connect"
+	GatewayCollectionGatewaysItemCrossAccountGateway_Type_Connect = "connect"
 	GatewayCollectionGatewaysItemCrossAccountGateway_Type_Dedicated = "dedicated"
 )
 
@@ -12040,7 +12140,7 @@ type GatewayCollectionGatewaysItemGateway struct {
 	// Gateway location.
 	LocationName *string `json:"location_name" validate:"required"`
 
-	// MACsec configuration information of a Direct Link gateway.
+	// MACsec configuration information of a direct link.
 	Macsec *GatewayMacsecReference `json:"macsec,omitempty"`
 
 	// Indicates the direct link's MACsec capability. It must match one of the MACsec related `capabilities` of the
@@ -12048,9 +12148,9 @@ type GatewayCollectionGatewaysItemGateway struct {
 	//
 	// Only included on type=dedicated direct links.
 	//
-	// - non_macsec: The direct link does not support MACsec.
-	// - macsec: The direct link supports MACsec. The MACsec feature must be enabled.
-	// - macsec_optional: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
+	// - `non_macsec`: The direct link does not support MACsec.
+	// - `macsec`: The direct link supports MACsec. The MACsec feature must be enabled.
+	// - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 	// direct link creation.
 	MacsecCapability *string `json:"macsec_capability,omitempty"`
 
@@ -12098,10 +12198,10 @@ type GatewayCollectionGatewaysItemGateway struct {
 // Gateway BGP status. The list of enumerated values for this property may expand in the future. Code and processes
 // using this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItemGateway_BgpStatus_Active      = "active"
-	GatewayCollectionGatewaysItemGateway_BgpStatus_Connect     = "connect"
+	GatewayCollectionGatewaysItemGateway_BgpStatus_Active = "active"
+	GatewayCollectionGatewaysItemGateway_BgpStatus_Connect = "connect"
 	GatewayCollectionGatewaysItemGateway_BgpStatus_Established = "established"
-	GatewayCollectionGatewaysItemGateway_BgpStatus_Idle        = "idle"
+	GatewayCollectionGatewaysItemGateway_BgpStatus_Idle = "idle"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemGateway.ConnectionMode property.
@@ -12109,21 +12209,21 @@ const (
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItemGateway_ConnectionMode_Direct  = "direct"
+	GatewayCollectionGatewaysItemGateway_ConnectionMode_Direct = "direct"
 	GatewayCollectionGatewaysItemGateway_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemGateway.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayCollectionGatewaysItemGateway_DefaultExportRouteFilter_Deny   = "deny"
+	GatewayCollectionGatewaysItemGateway_DefaultExportRouteFilter_Deny = "deny"
 	GatewayCollectionGatewaysItemGateway_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemGateway.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayCollectionGatewaysItemGateway_DefaultImportRouteFilter_Deny   = "deny"
+	GatewayCollectionGatewaysItemGateway_DefaultImportRouteFilter_Deny = "deny"
 	GatewayCollectionGatewaysItemGateway_DefaultImportRouteFilter_Permit = "permit"
 )
 
@@ -12132,7 +12232,7 @@ const (
 // expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
 	GatewayCollectionGatewaysItemGateway_LinkStatus_Down = "down"
-	GatewayCollectionGatewaysItemGateway_LinkStatus_Up   = "up"
+	GatewayCollectionGatewaysItemGateway_LinkStatus_Up = "up"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemGateway.MacsecCapability property.
@@ -12141,14 +12241,14 @@ const (
 //
 // Only included on type=dedicated direct links.
 //
-// - non_macsec: The direct link does not support MACsec.
-// - macsec: The direct link supports MACsec. The MACsec feature must be enabled.
-// - macsec_optional: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
+// - `non_macsec`: The direct link does not support MACsec.
+// - `macsec`: The direct link supports MACsec. The MACsec feature must be enabled.
+// - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 // direct link creation.
 const (
-	GatewayCollectionGatewaysItemGateway_MacsecCapability_Macsec         = "macsec"
+	GatewayCollectionGatewaysItemGateway_MacsecCapability_Macsec = "macsec"
 	GatewayCollectionGatewaysItemGateway_MacsecCapability_MacsecOptional = "macsec_optional"
-	GatewayCollectionGatewaysItemGateway_MacsecCapability_NonMacsec      = "non_macsec"
+	GatewayCollectionGatewaysItemGateway_MacsecCapability_NonMacsec = "non_macsec"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemGateway.OperationalStatus property.
@@ -12158,26 +12258,26 @@ const (
 // See `operational_status_reasons[]` for possible remediation of the `failed` `operational_status`.
 const (
 	GatewayCollectionGatewaysItemGateway_OperationalStatus_AwaitingCompletionNotice = "awaiting_completion_notice"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_AwaitingLoa              = "awaiting_loa"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_AwaitingLoa = "awaiting_loa"
 	GatewayCollectionGatewaysItemGateway_OperationalStatus_CompletionNoticeApproved = "completion_notice_approved"
 	GatewayCollectionGatewaysItemGateway_OperationalStatus_CompletionNoticeReceived = "completion_notice_received"
 	GatewayCollectionGatewaysItemGateway_OperationalStatus_CompletionNoticeRejected = "completion_notice_rejected"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_Configuring              = "configuring"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_CreatePending            = "create_pending"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_CreateRejected           = "create_rejected"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_DeletePending            = "delete_pending"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_Failed                   = "failed"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_LoaAccepted              = "loa_accepted"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_LoaCreated               = "loa_created"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_LoaRejected              = "loa_rejected"
-	GatewayCollectionGatewaysItemGateway_OperationalStatus_Provisioned              = "provisioned"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_Configuring = "configuring"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_CreatePending = "create_pending"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_CreateRejected = "create_rejected"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_DeletePending = "delete_pending"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_Failed = "failed"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_LoaAccepted = "loa_accepted"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_LoaCreated = "loa_created"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_LoaRejected = "loa_rejected"
+	GatewayCollectionGatewaysItemGateway_OperationalStatus_Provisioned = "provisioned"
 )
 
 // Constants associated with the GatewayCollectionGatewaysItemGateway.Type property.
 // Offering type. The list of enumerated values for this property may expand in the future. Code and processes using
 // this field  must tolerate unexpected values.
 const (
-	GatewayCollectionGatewaysItemGateway_Type_Connect   = "connect"
+	GatewayCollectionGatewaysItemGateway_Type_Connect = "connect"
 	GatewayCollectionGatewaysItemGateway_Type_Dedicated = "dedicated"
 )
 
@@ -12392,6 +12492,98 @@ func UnmarshalGatewayCollectionGatewaysItemGateway(m map[string]json.RawMessage,
 	return
 }
 
+// GatewayMacsecCakKeyReferenceHpcsCakKeyReference : A reference to a [Hyper Protect Crypto Service Standard
+// Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started).
+// This model "extends" GatewayMacsecCakKeyReference
+type GatewayMacsecCakKeyReferenceHpcsCakKeyReference struct {
+	// The CRN of the referenced key.
+	Crn *string `json:"crn" validate:"required"`
+}
+
+// NewGatewayMacsecCakKeyReferenceHpcsCakKeyReference : Instantiate GatewayMacsecCakKeyReferenceHpcsCakKeyReference (Generic Model Constructor)
+func (*DirectLinkV1) NewGatewayMacsecCakKeyReferenceHpcsCakKeyReference(crn string) (_model *GatewayMacsecCakKeyReferenceHpcsCakKeyReference, err error) {
+	_model = &GatewayMacsecCakKeyReferenceHpcsCakKeyReference{
+		Crn: core.StringPtr(crn),
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "model-missing-required", common.GetComponentInfo())
+	}
+	return
+}
+
+func (*GatewayMacsecCakKeyReferenceHpcsCakKeyReference) isaGatewayMacsecCakKeyReference() bool {
+	return true
+}
+
+// UnmarshalGatewayMacsecCakKeyReferenceHpcsCakKeyReference unmarshals an instance of GatewayMacsecCakKeyReferenceHpcsCakKeyReference from the specified map of raw messages.
+func UnmarshalGatewayMacsecCakKeyReferenceHpcsCakKeyReference(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+	err = core.UnmarshalPrimitive(m, "crn", &obj.Crn)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "crn-error", common.GetComponentInfo())
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// asPatch returns a generic map representation of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference
+func (gatewayMacsecCakKeyReferenceHpcsCakKeyReference *GatewayMacsecCakKeyReferenceHpcsCakKeyReference) asPatch() (_patch map[string]interface{}) {
+	_patch = map[string]interface{}{}
+	if !core.IsNil(gatewayMacsecCakKeyReferenceHpcsCakKeyReference.Crn) {
+		_patch["crn"] = gatewayMacsecCakKeyReferenceHpcsCakKeyReference.Crn
+	}
+
+	return
+}
+
+// GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference : A reference to a [Secrets Manager Arbitrary
+// Secret](https://cloud.ibm.com/docs/secrets-manager?topic=secrets-manager-getting-started).
+// This model "extends" GatewayMacsecCakKeyReference
+type GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference struct {
+	// The CRN of the referenced key.
+	Crn *string `json:"crn" validate:"required"`
+}
+
+// NewGatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference : Instantiate GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference (Generic Model Constructor)
+func (*DirectLinkV1) NewGatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference(crn string) (_model *GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference, err error) {
+	_model = &GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference{
+		Crn: core.StringPtr(crn),
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "model-missing-required", common.GetComponentInfo())
+	}
+	return
+}
+
+func (*GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference) isaGatewayMacsecCakKeyReference() bool {
+	return true
+}
+
+// UnmarshalGatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference unmarshals an instance of GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference from the specified map of raw messages.
+func UnmarshalGatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference)
+	err = core.UnmarshalPrimitive(m, "crn", &obj.Crn)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "crn-error", common.GetComponentInfo())
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// asPatch returns a generic map representation of the GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference
+func (gatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference *GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference) asPatch() (_patch map[string]interface{}) {
+	_patch = map[string]interface{}{}
+	if !core.IsNil(gatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference.Crn) {
+		_patch["crn"] = gatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference.Crn
+	}
+
+	return
+}
+
 // GatewayStatusGatewayBFDStatus : Gateway bfd status.
 // This model "extends" GatewayStatus
 type GatewayStatusGatewayBFDStatus struct {
@@ -12414,10 +12606,10 @@ const (
 // Constants associated with the GatewayStatusGatewayBFDStatus.Value property.
 // Status.
 const (
-	GatewayStatusGatewayBFDStatus_Value_Down         = "down"
-	GatewayStatusGatewayBFDStatus_Value_Init         = "init"
+	GatewayStatusGatewayBFDStatus_Value_Down = "down"
+	GatewayStatusGatewayBFDStatus_Value_Init = "init"
 	GatewayStatusGatewayBFDStatus_Value_NotAvailable = "not_available"
-	GatewayStatusGatewayBFDStatus_Value_Up           = "up"
+	GatewayStatusGatewayBFDStatus_Value_Up = "up"
 )
 
 func (*GatewayStatusGatewayBFDStatus) isaGatewayStatus() bool {
@@ -12468,10 +12660,10 @@ const (
 // Constants associated with the GatewayStatusGatewayBGPStatus.Value property.
 // Status.
 const (
-	GatewayStatusGatewayBGPStatus_Value_Active      = "active"
-	GatewayStatusGatewayBGPStatus_Value_Connect     = "connect"
+	GatewayStatusGatewayBGPStatus_Value_Active = "active"
+	GatewayStatusGatewayBGPStatus_Value_Connect = "connect"
 	GatewayStatusGatewayBGPStatus_Value_Established = "established"
-	GatewayStatusGatewayBGPStatus_Value_Idle        = "idle"
+	GatewayStatusGatewayBGPStatus_Value_Idle = "idle"
 )
 
 func (*GatewayStatusGatewayBGPStatus) isaGatewayStatus() bool {
@@ -12523,7 +12715,7 @@ const (
 // Status.
 const (
 	GatewayStatusGatewayLinkStatus_Value_Down = "down"
-	GatewayStatusGatewayLinkStatus_Value_Up   = "up"
+	GatewayStatusGatewayLinkStatus_Value_Up = "up"
 )
 
 func (*GatewayStatusGatewayLinkStatus) isaGatewayStatus() bool {
@@ -12642,41 +12834,41 @@ type GatewayTemplateGatewayTypeConnectTemplate struct {
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GatewayTemplateGatewayTypeConnectTemplate_ConnectionMode_Direct  = "direct"
+	GatewayTemplateGatewayTypeConnectTemplate_ConnectionMode_Direct = "direct"
 	GatewayTemplateGatewayTypeConnectTemplate_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GatewayTemplateGatewayTypeConnectTemplate.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayTemplateGatewayTypeConnectTemplate_DefaultExportRouteFilter_Deny   = "deny"
+	GatewayTemplateGatewayTypeConnectTemplate_DefaultExportRouteFilter_Deny = "deny"
 	GatewayTemplateGatewayTypeConnectTemplate_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayTemplateGatewayTypeConnectTemplate.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayTemplateGatewayTypeConnectTemplate_DefaultImportRouteFilter_Deny   = "deny"
+	GatewayTemplateGatewayTypeConnectTemplate_DefaultImportRouteFilter_Deny = "deny"
 	GatewayTemplateGatewayTypeConnectTemplate_DefaultImportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayTemplateGatewayTypeConnectTemplate.Type property.
 // Offering type.
 const (
-	GatewayTemplateGatewayTypeConnectTemplate_Type_Connect   = "connect"
+	GatewayTemplateGatewayTypeConnectTemplate_Type_Connect = "connect"
 	GatewayTemplateGatewayTypeConnectTemplate_Type_Dedicated = "dedicated"
 )
 
 // NewGatewayTemplateGatewayTypeConnectTemplate : Instantiate GatewayTemplateGatewayTypeConnectTemplate (Generic Model Constructor)
 func (*DirectLinkV1) NewGatewayTemplateGatewayTypeConnectTemplate(bgpAsn int64, global bool, metered bool, name string, speedMbps int64, typeVar string, port *GatewayPortIdentity) (_model *GatewayTemplateGatewayTypeConnectTemplate, err error) {
 	_model = &GatewayTemplateGatewayTypeConnectTemplate{
-		BgpAsn:    core.Int64Ptr(bgpAsn),
-		Global:    core.BoolPtr(global),
-		Metered:   core.BoolPtr(metered),
-		Name:      core.StringPtr(name),
+		BgpAsn: core.Int64Ptr(bgpAsn),
+		Global: core.BoolPtr(global),
+		Metered: core.BoolPtr(metered),
+		Name: core.StringPtr(name),
 		SpeedMbps: core.Int64Ptr(speedMbps),
-		Type:      core.StringPtr(typeVar),
-		Port:      port,
+		Type: core.StringPtr(typeVar),
+		Port: port,
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	if err != nil {
@@ -12889,15 +13081,15 @@ type GatewayTemplateGatewayTypeDedicatedTemplate struct {
 	// Gateway location.
 	LocationName *string `json:"location_name" validate:"required"`
 
-	// MACsec configuration information of a Direct Link gateway.
+	// MACsec configuration information of a direct link.
 	Macsec *GatewayMacsecPrototype `json:"macsec,omitempty"`
 
 	// Indicates the direct link's MACsec capability. It must match one of the MACsec related `capabilities` of the
 	// `cross_connect_router`.
 	//
-	// - non_macsec: The direct link does not support MACsec.
-	// - macsec: The direct link supports MACsec. The MACsec feature must be enabled.
-	// - macsec_optional: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
+	// - `non_macsec`: The direct link does not support MACsec.
+	// - `macsec`: The direct link supports MACsec. The MACsec feature must be enabled.
+	// - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 	// direct link creation.
 	//
 	// If not explicitly provided, the field will be assigned with the following priorities based on `cross_connect_router`
@@ -12919,28 +13111,28 @@ type GatewayTemplateGatewayTypeDedicatedTemplate struct {
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GatewayTemplateGatewayTypeDedicatedTemplate_ConnectionMode_Direct  = "direct"
+	GatewayTemplateGatewayTypeDedicatedTemplate_ConnectionMode_Direct = "direct"
 	GatewayTemplateGatewayTypeDedicatedTemplate_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GatewayTemplateGatewayTypeDedicatedTemplate.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayTemplateGatewayTypeDedicatedTemplate_DefaultExportRouteFilter_Deny   = "deny"
+	GatewayTemplateGatewayTypeDedicatedTemplate_DefaultExportRouteFilter_Deny = "deny"
 	GatewayTemplateGatewayTypeDedicatedTemplate_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayTemplateGatewayTypeDedicatedTemplate.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GatewayTemplateGatewayTypeDedicatedTemplate_DefaultImportRouteFilter_Deny   = "deny"
+	GatewayTemplateGatewayTypeDedicatedTemplate_DefaultImportRouteFilter_Deny = "deny"
 	GatewayTemplateGatewayTypeDedicatedTemplate_DefaultImportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GatewayTemplateGatewayTypeDedicatedTemplate.Type property.
 // Offering type.
 const (
-	GatewayTemplateGatewayTypeDedicatedTemplate_Type_Connect   = "connect"
+	GatewayTemplateGatewayTypeDedicatedTemplate_Type_Connect = "connect"
 	GatewayTemplateGatewayTypeDedicatedTemplate_Type_Dedicated = "dedicated"
 )
 
@@ -12948,38 +13140,38 @@ const (
 // Indicates the direct link's MACsec capability. It must match one of the MACsec related `capabilities` of the
 // `cross_connect_router`.
 //
-// - non_macsec: The direct link does not support MACsec.
-// - macsec: The direct link supports MACsec. The MACsec feature must be enabled.
-// - macsec_optional: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
+// - `non_macsec`: The direct link does not support MACsec.
+// - `macsec`: The direct link supports MACsec. The MACsec feature must be enabled.
+// - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 // direct link creation.
 //
 // If not explicitly provided, the field will be assigned with the following priorities based on `cross_connect_router`
 // capabilities and available ports:
 //   - `macsec` was not provided in the request
-//   - `non_macsec`
-//   - `macsec_optional`
+//     - `non_macsec`
+//     - `macsec_optional`
 //   - `macsec` was provided in the request
-//   - `macsec_optional`
-//   - `macsec`.
+//     - `macsec_optional`
+//     - `macsec`.
 const (
-	GatewayTemplateGatewayTypeDedicatedTemplate_MacsecCapability_Macsec         = "macsec"
+	GatewayTemplateGatewayTypeDedicatedTemplate_MacsecCapability_Macsec = "macsec"
 	GatewayTemplateGatewayTypeDedicatedTemplate_MacsecCapability_MacsecOptional = "macsec_optional"
-	GatewayTemplateGatewayTypeDedicatedTemplate_MacsecCapability_NonMacsec      = "non_macsec"
+	GatewayTemplateGatewayTypeDedicatedTemplate_MacsecCapability_NonMacsec = "non_macsec"
 )
 
 // NewGatewayTemplateGatewayTypeDedicatedTemplate : Instantiate GatewayTemplateGatewayTypeDedicatedTemplate (Generic Model Constructor)
 func (*DirectLinkV1) NewGatewayTemplateGatewayTypeDedicatedTemplate(bgpAsn int64, global bool, metered bool, name string, speedMbps int64, typeVar string, carrierName string, crossConnectRouter string, customerName string, locationName string) (_model *GatewayTemplateGatewayTypeDedicatedTemplate, err error) {
 	_model = &GatewayTemplateGatewayTypeDedicatedTemplate{
-		BgpAsn:             core.Int64Ptr(bgpAsn),
-		Global:             core.BoolPtr(global),
-		Metered:            core.BoolPtr(metered),
-		Name:               core.StringPtr(name),
-		SpeedMbps:          core.Int64Ptr(speedMbps),
-		Type:               core.StringPtr(typeVar),
-		CarrierName:        core.StringPtr(carrierName),
+		BgpAsn: core.Int64Ptr(bgpAsn),
+		Global: core.BoolPtr(global),
+		Metered: core.BoolPtr(metered),
+		Name: core.StringPtr(name),
+		SpeedMbps: core.Int64Ptr(speedMbps),
+		Type: core.StringPtr(typeVar),
+		CarrierName: core.StringPtr(carrierName),
 		CrossConnectRouter: core.StringPtr(crossConnectRouter),
-		CustomerName:       core.StringPtr(customerName),
-		LocationName:       core.StringPtr(locationName),
+		CustomerName: core.StringPtr(customerName),
+		LocationName: core.StringPtr(locationName),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	if err != nil {
@@ -13197,10 +13389,10 @@ type GetGatewayResponseCrossAccountGateway struct {
 // Gateway BGP status. The list of enumerated values for this property may expand in the future. Code and processes
 // using this field  must tolerate unexpected values.
 const (
-	GetGatewayResponseCrossAccountGateway_BgpStatus_Active      = "active"
-	GetGatewayResponseCrossAccountGateway_BgpStatus_Connect     = "connect"
+	GetGatewayResponseCrossAccountGateway_BgpStatus_Active = "active"
+	GetGatewayResponseCrossAccountGateway_BgpStatus_Connect = "connect"
 	GetGatewayResponseCrossAccountGateway_BgpStatus_Established = "established"
-	GetGatewayResponseCrossAccountGateway_BgpStatus_Idle        = "idle"
+	GetGatewayResponseCrossAccountGateway_BgpStatus_Idle = "idle"
 )
 
 // Constants associated with the GetGatewayResponseCrossAccountGateway.ConnectionMode property.
@@ -13208,7 +13400,7 @@ const (
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GetGatewayResponseCrossAccountGateway_ConnectionMode_Direct  = "direct"
+	GetGatewayResponseCrossAccountGateway_ConnectionMode_Direct = "direct"
 	GetGatewayResponseCrossAccountGateway_ConnectionMode_Transit = "transit"
 )
 
@@ -13217,7 +13409,7 @@ const (
 // expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
 	GetGatewayResponseCrossAccountGateway_LinkStatus_Down = "down"
-	GetGatewayResponseCrossAccountGateway_LinkStatus_Up   = "up"
+	GetGatewayResponseCrossAccountGateway_LinkStatus_Up = "up"
 )
 
 // Constants associated with the GetGatewayResponseCrossAccountGateway.OperationalStatus property.
@@ -13225,25 +13417,25 @@ const (
 // processes using this field  must tolerate unexpected values.
 const (
 	GetGatewayResponseCrossAccountGateway_OperationalStatus_AwaitingCompletionNotice = "awaiting_completion_notice"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_AwaitingLoa              = "awaiting_loa"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_AwaitingLoa = "awaiting_loa"
 	GetGatewayResponseCrossAccountGateway_OperationalStatus_CompletionNoticeApproved = "completion_notice_approved"
 	GetGatewayResponseCrossAccountGateway_OperationalStatus_CompletionNoticeReceived = "completion_notice_received"
 	GetGatewayResponseCrossAccountGateway_OperationalStatus_CompletionNoticeRejected = "completion_notice_rejected"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_Configuring              = "configuring"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_CreatePending            = "create_pending"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_CreateRejected           = "create_rejected"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_DeletePending            = "delete_pending"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_LoaAccepted              = "loa_accepted"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_LoaCreated               = "loa_created"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_LoaRejected              = "loa_rejected"
-	GetGatewayResponseCrossAccountGateway_OperationalStatus_Provisioned              = "provisioned"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_Configuring = "configuring"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_CreatePending = "create_pending"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_CreateRejected = "create_rejected"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_DeletePending = "delete_pending"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_LoaAccepted = "loa_accepted"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_LoaCreated = "loa_created"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_LoaRejected = "loa_rejected"
+	GetGatewayResponseCrossAccountGateway_OperationalStatus_Provisioned = "provisioned"
 )
 
 // Constants associated with the GetGatewayResponseCrossAccountGateway.Type property.
 // Offering type. The list of enumerated values for this property may expand in the future. Code and processes using
 // this field  must tolerate unexpected values.
 const (
-	GetGatewayResponseCrossAccountGateway_Type_Connect   = "connect"
+	GetGatewayResponseCrossAccountGateway_Type_Connect = "connect"
 	GetGatewayResponseCrossAccountGateway_Type_Dedicated = "dedicated"
 )
 
@@ -13439,7 +13631,7 @@ type GetGatewayResponseGateway struct {
 	// Gateway location.
 	LocationName *string `json:"location_name" validate:"required"`
 
-	// MACsec configuration information of a Direct Link gateway.
+	// MACsec configuration information of a direct link.
 	Macsec *GatewayMacsecReference `json:"macsec,omitempty"`
 
 	// Indicates the direct link's MACsec capability. It must match one of the MACsec related `capabilities` of the
@@ -13447,9 +13639,9 @@ type GetGatewayResponseGateway struct {
 	//
 	// Only included on type=dedicated direct links.
 	//
-	// - non_macsec: The direct link does not support MACsec.
-	// - macsec: The direct link supports MACsec. The MACsec feature must be enabled.
-	// - macsec_optional: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
+	// - `non_macsec`: The direct link does not support MACsec.
+	// - `macsec`: The direct link supports MACsec. The MACsec feature must be enabled.
+	// - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 	// direct link creation.
 	MacsecCapability *string `json:"macsec_capability,omitempty"`
 
@@ -13497,10 +13689,10 @@ type GetGatewayResponseGateway struct {
 // Gateway BGP status. The list of enumerated values for this property may expand in the future. Code and processes
 // using this field  must tolerate unexpected values.
 const (
-	GetGatewayResponseGateway_BgpStatus_Active      = "active"
-	GetGatewayResponseGateway_BgpStatus_Connect     = "connect"
+	GetGatewayResponseGateway_BgpStatus_Active = "active"
+	GetGatewayResponseGateway_BgpStatus_Connect = "connect"
 	GetGatewayResponseGateway_BgpStatus_Established = "established"
-	GetGatewayResponseGateway_BgpStatus_Idle        = "idle"
+	GetGatewayResponseGateway_BgpStatus_Idle = "idle"
 )
 
 // Constants associated with the GetGatewayResponseGateway.ConnectionMode property.
@@ -13508,21 +13700,21 @@ const (
 // Service and direct means this Gateway will be attached to vpc or classic connection. The list of enumerated values
 // for this property may expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
-	GetGatewayResponseGateway_ConnectionMode_Direct  = "direct"
+	GetGatewayResponseGateway_ConnectionMode_Direct = "direct"
 	GetGatewayResponseGateway_ConnectionMode_Transit = "transit"
 )
 
 // Constants associated with the GetGatewayResponseGateway.DefaultExportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GetGatewayResponseGateway_DefaultExportRouteFilter_Deny   = "deny"
+	GetGatewayResponseGateway_DefaultExportRouteFilter_Deny = "deny"
 	GetGatewayResponseGateway_DefaultExportRouteFilter_Permit = "permit"
 )
 
 // Constants associated with the GetGatewayResponseGateway.DefaultImportRouteFilter property.
 // The default directional route filter action that applies to routes that do not match any directional route filters.
 const (
-	GetGatewayResponseGateway_DefaultImportRouteFilter_Deny   = "deny"
+	GetGatewayResponseGateway_DefaultImportRouteFilter_Deny = "deny"
 	GetGatewayResponseGateway_DefaultImportRouteFilter_Permit = "permit"
 )
 
@@ -13531,7 +13723,7 @@ const (
 // expand in the future. Code and processes using this field  must tolerate unexpected values.
 const (
 	GetGatewayResponseGateway_LinkStatus_Down = "down"
-	GetGatewayResponseGateway_LinkStatus_Up   = "up"
+	GetGatewayResponseGateway_LinkStatus_Up = "up"
 )
 
 // Constants associated with the GetGatewayResponseGateway.MacsecCapability property.
@@ -13540,14 +13732,14 @@ const (
 //
 // Only included on type=dedicated direct links.
 //
-// - non_macsec: The direct link does not support MACsec.
-// - macsec: The direct link supports MACsec. The MACsec feature must be enabled.
-// - macsec_optional: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
+// - `non_macsec`: The direct link does not support MACsec.
+// - `macsec`: The direct link supports MACsec. The MACsec feature must be enabled.
+// - `macsec_optional`: The direct link supports MACsec. The MACsec feature is not required and can be enabled after
 // direct link creation.
 const (
-	GetGatewayResponseGateway_MacsecCapability_Macsec         = "macsec"
+	GetGatewayResponseGateway_MacsecCapability_Macsec = "macsec"
 	GetGatewayResponseGateway_MacsecCapability_MacsecOptional = "macsec_optional"
-	GetGatewayResponseGateway_MacsecCapability_NonMacsec      = "non_macsec"
+	GetGatewayResponseGateway_MacsecCapability_NonMacsec = "non_macsec"
 )
 
 // Constants associated with the GetGatewayResponseGateway.OperationalStatus property.
@@ -13557,26 +13749,26 @@ const (
 // See `operational_status_reasons[]` for possible remediation of the `failed` `operational_status`.
 const (
 	GetGatewayResponseGateway_OperationalStatus_AwaitingCompletionNotice = "awaiting_completion_notice"
-	GetGatewayResponseGateway_OperationalStatus_AwaitingLoa              = "awaiting_loa"
+	GetGatewayResponseGateway_OperationalStatus_AwaitingLoa = "awaiting_loa"
 	GetGatewayResponseGateway_OperationalStatus_CompletionNoticeApproved = "completion_notice_approved"
 	GetGatewayResponseGateway_OperationalStatus_CompletionNoticeReceived = "completion_notice_received"
 	GetGatewayResponseGateway_OperationalStatus_CompletionNoticeRejected = "completion_notice_rejected"
-	GetGatewayResponseGateway_OperationalStatus_Configuring              = "configuring"
-	GetGatewayResponseGateway_OperationalStatus_CreatePending            = "create_pending"
-	GetGatewayResponseGateway_OperationalStatus_CreateRejected           = "create_rejected"
-	GetGatewayResponseGateway_OperationalStatus_DeletePending            = "delete_pending"
-	GetGatewayResponseGateway_OperationalStatus_Failed                   = "failed"
-	GetGatewayResponseGateway_OperationalStatus_LoaAccepted              = "loa_accepted"
-	GetGatewayResponseGateway_OperationalStatus_LoaCreated               = "loa_created"
-	GetGatewayResponseGateway_OperationalStatus_LoaRejected              = "loa_rejected"
-	GetGatewayResponseGateway_OperationalStatus_Provisioned              = "provisioned"
+	GetGatewayResponseGateway_OperationalStatus_Configuring = "configuring"
+	GetGatewayResponseGateway_OperationalStatus_CreatePending = "create_pending"
+	GetGatewayResponseGateway_OperationalStatus_CreateRejected = "create_rejected"
+	GetGatewayResponseGateway_OperationalStatus_DeletePending = "delete_pending"
+	GetGatewayResponseGateway_OperationalStatus_Failed = "failed"
+	GetGatewayResponseGateway_OperationalStatus_LoaAccepted = "loa_accepted"
+	GetGatewayResponseGateway_OperationalStatus_LoaCreated = "loa_created"
+	GetGatewayResponseGateway_OperationalStatus_LoaRejected = "loa_rejected"
+	GetGatewayResponseGateway_OperationalStatus_Provisioned = "provisioned"
 )
 
 // Constants associated with the GetGatewayResponseGateway.Type property.
 // Offering type. The list of enumerated values for this property may expand in the future. Code and processes using
 // this field  must tolerate unexpected values.
 const (
-	GetGatewayResponseGateway_Type_Connect   = "connect"
+	GetGatewayResponseGateway_Type_Connect = "connect"
 	GetGatewayResponseGateway_Type_Dedicated = "dedicated"
 )
 
@@ -13850,7 +14042,7 @@ type RouteReportOverlappingRouteForOthers struct {
 // type of the route.
 const (
 	RouteReportOverlappingRouteForOthers_Type_Gateway = "gateway"
-	RouteReportOverlappingRouteForOthers_Type_OnPrem  = "on_prem"
+	RouteReportOverlappingRouteForOthers_Type_OnPrem = "on_prem"
 )
 
 func (*RouteReportOverlappingRouteForOthers) isaRouteReportOverlappingRoute() bool {
@@ -13976,7 +14168,7 @@ const (
 func (*DirectLinkV1) NewSakRekeyPatchSakRekeyTimerModePatch(interval int64, mode string) (_model *SakRekeyPatchSakRekeyTimerModePatch, err error) {
 	_model = &SakRekeyPatchSakRekeyTimerModePatch{
 		Interval: core.Int64Ptr(interval),
-		Mode:     core.StringPtr(mode),
+		Mode: core.StringPtr(mode),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	if err != nil {
@@ -14081,7 +14273,7 @@ const (
 func (*DirectLinkV1) NewSakRekeyPrototypeSakRekeyTimerModePrototype(interval int64, mode string) (_model *SakRekeyPrototypeSakRekeyTimerModePrototype, err error) {
 	_model = &SakRekeyPrototypeSakRekeyTimerModePrototype{
 		Interval: core.Int64Ptr(interval),
-		Mode:     core.StringPtr(mode),
+		Mode: core.StringPtr(mode),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	if err != nil {
@@ -14148,11 +14340,13 @@ func UnmarshalSakRekeyTimerMode(m map[string]json.RawMessage, result interface{}
 	return
 }
 
+//
 // PortsPager can be used to simplify the use of the "ListPorts" method.
+//
 type PortsPager struct {
-	hasNext     bool
-	options     *ListPortsOptions
-	client      *DirectLinkV1
+	hasNext bool
+	options *ListPortsOptions
+	client  *DirectLinkV1
 	pageContext struct {
 		next *string
 	}

--- a/directlinkv1/direct_link_v1_integration_test.go
+++ b/directlinkv1/direct_link_v1_integration_test.go
@@ -1763,103 +1763,123 @@ var _ = Describe(`DirectLinkV1`, func() {
 			})
 		})
 	})
-	/*
-		 Describe("BGP MD5", func() {
-			 timestamp := time.Now().Unix()
-			 gatewayName := "GO-INT-MD5-SDK-" + strconv.FormatInt(timestamp, 10)
-			 bgpAsn := int64(64999)
-			 crossConnectRouter := "LAB-xcr01.dal09"
-			 global := true
-			 locationName := os.Getenv("LOCATION_NAME")
-			 speedMbps := int64(1000)
-			 metered := false
-			 carrierName := "carrier1"
-			 customerName := "customer1"
-			 gatewayType := "dedicated"
-			 authCrn := os.Getenv("AUTHENTICATION_KEY")
+	Describe("BGP MD5", func() {
+		timestamp := time.Now().Unix()
+		gatewayName := "GO-INT-MD5-SDK-" + strconv.FormatInt(timestamp, 10)
+		bgpAsn := int64(64999)
+		crossConnectRouter := "LAB-xcr01.dal09"
+		global := true
+		locationName := os.Getenv("LOCATION_NAME")
+		speedMbps := int64(1000)
+		metered := false
+		carrierName := "carrier1"
+		customerName := "customer1"
+		gatewayType := "dedicated"
+		authCrn := os.Getenv("AUTHENTICATION_KEY")
 
-			 Context("Create a Gateway with Authentication Key", func() {
-				 It("should successfully create a gateway", func() {
-					 shouldSkipTest()
+		Context("Create a Gateway with Authentication Key", func() {
+			It("should successfully create a gateway", func() {
+				shouldSkipTest()
 
-					 // gateway, _ := service.NewGatewayTemplateGatewayTypeDedicatedTemplate(bgpAsn, global, metered, gatewayName, speedMbps, gatewayType, carrierName, crossConnectRouter, customerName, locationName)
-					 authenticationKey, _ := service.NewGatewayTemplateAuthenticationKey(authCrn)
+				// Create authentication key using new SDK model
+				// SDK automatically determines service type from CRN format
+				authenticationKey, err := service.NewAuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity(authCrn)
+				Expect(err).To(BeNil())
 
-					 gatewayTemplateModel := new(directlinkv1.GatewayTemplateGatewayTypeDedicatedTemplate)
-					 gatewayTemplateModel.AuthenticationKey = authenticationKey
-					 gatewayTemplateModel.BgpAsn = core.Int64Ptr(int64(64999))
-					 gatewayTemplateModel.Global = core.BoolPtr(true)
-					 gatewayTemplateModel.Metered = core.BoolPtr(false)
-					 gatewayTemplateModel.Name = core.StringPtr(gatewayName)
-					 gatewayTemplateModel.SpeedMbps = core.Int64Ptr(int64(1000))
-					 gatewayTemplateModel.Type = core.StringPtr(gatewayType)
-					 gatewayTemplateModel.CarrierName = core.StringPtr(carrierName)
-					 gatewayTemplateModel.CrossConnectRouter = core.StringPtr(crossConnectRouter)
-					 gatewayTemplateModel.CustomerName = core.StringPtr(customerName)
-					 gatewayTemplateModel.LocationName = core.StringPtr(locationName)
+				gatewayTemplateModel := new(directlinkv1.GatewayTemplateGatewayTypeDedicatedTemplate)
+				gatewayTemplateModel.AuthenticationKey = authenticationKey
+				gatewayTemplateModel.BgpAsn = core.Int64Ptr(bgpAsn)
+				gatewayTemplateModel.Global = core.BoolPtr(global)
+				gatewayTemplateModel.Metered = core.BoolPtr(metered)
+				gatewayTemplateModel.Name = core.StringPtr("GO-INT-MD5-SDK-" + strconv.FormatInt(timestamp, 10))
+				gatewayTemplateModel.SpeedMbps = core.Int64Ptr(speedMbps)
+				gatewayTemplateModel.Type = core.StringPtr(gatewayType)
+				gatewayTemplateModel.CarrierName = core.StringPtr(carrierName)
+				gatewayTemplateModel.CrossConnectRouter = core.StringPtr(crossConnectRouter)
+				gatewayTemplateModel.CustomerName = core.StringPtr(customerName)
+				gatewayTemplateModel.LocationName = core.StringPtr(locationName)
 
-					 createGatewayOptions := service.NewCreateGatewayOptions(gatewayTemplateModel)
+				createGatewayOptions := service.NewCreateGatewayOptions(gatewayTemplateModel)
 
-					 result, resp, err := service.CreateGateway(createGatewayOptions)
+				result, resp, err := service.CreateGateway(createGatewayOptions)
 
-					 Expect(err).To(BeNil())
-					 Expect(resp.StatusCode).To(Equal(201))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(201))
 
-					 os.Setenv("GATEWAY_ID", *result.ID)
+				os.Setenv("GATEWAY_ID", *result.ID)
 
-					 Expect(*result.Name).To(Equal(gatewayName))
-					 Expect(*result.AuthenticationKey.Crn).To(Equal(authCrn))
-					 Expect(*result.BgpAsn).To(Equal(bgpAsn))
-					 Expect(*result.Global).To(Equal(global))
-					 Expect(*result.Metered).To(Equal(metered))
-					 Expect(*result.SpeedMbps).To(Equal(speedMbps))
-					 Expect(*result.Type).To(Equal(gatewayType))
-					 Expect(*result.CrossConnectRouter).To(Equal(crossConnectRouter))
-					 Expect(*result.LocationName).To(Equal(locationName))
-					 Expect(*result.LocationDisplayName).NotTo(Equal(""))
-					 Expect(*result.BgpCerCidr).NotTo(BeEmpty())
-					 Expect(*result.BgpIbmCidr).NotTo(Equal(""))
-					 Expect(*result.BgpIbmAsn).NotTo(Equal(""))
-					 Expect(*result.CreatedAt).NotTo(Equal(""))
-					 Expect(*result.Crn).To(HavePrefix("crn:v1"))
-					 Expect(*result.LinkStatus).To(Equal("down"))
-					 Expect(*result.OperationalStatus).To(Equal("awaiting_loa"))
-					 Expect(*result.ResourceGroup.ID).NotTo(Equal(""))
+				Expect(*result.Name).To(Equal(gatewayName))
+				// AuthenticationKey is now an interface, verify it exists and has correct CRN
+				Expect(result.AuthenticationKey).ToNot(BeNil())
+				// Type assert to get the CRN - works for any service (SM, HPCS, Key Protect)
+				switch authKey := result.AuthenticationKey.(type) {
+				case *directlinkv1.AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference:
+					Expect(*authKey.Crn).To(Equal(authCrn))
+				case *directlinkv1.AuthenticationKeyReferenceHpcsAuthenticationKeyReference:
+					Expect(*authKey.Crn).To(Equal(authCrn))
+				case *directlinkv1.AuthenticationKeyReferenceKeyProtectAuthenticationKeyReference:
+					Expect(*authKey.Crn).To(Equal(authCrn))
+				}
+				Expect(*result.BgpAsn).To(Equal(bgpAsn))
+				Expect(*result.Global).To(Equal(global))
+				Expect(*result.Metered).To(Equal(metered))
+				Expect(*result.SpeedMbps).To(Equal(speedMbps))
+				Expect(*result.Type).To(Equal(gatewayType))
+				Expect(*result.CrossConnectRouter).To(Equal(crossConnectRouter))
+				Expect(*result.LocationName).To(Equal(locationName))
+				Expect(*result.LocationDisplayName).NotTo(Equal(""))
+				Expect(*result.BgpCerCidr).NotTo(BeEmpty())
+				Expect(*result.BgpIbmCidr).NotTo(Equal(""))
+				Expect(*result.BgpIbmAsn).NotTo(Equal(""))
+				Expect(*result.CreatedAt).NotTo(Equal(""))
+				Expect(*result.Crn).To(HavePrefix("crn:v1"))
+				Expect(*result.LinkStatus).To(Equal("down"))
+				Expect(*result.OperationalStatus).To(Equal("awaiting_loa"))
+				Expect(*result.ResourceGroup.ID).NotTo(Equal(""))
 
-				 })
-			 })
+			})
+		})
 
-			 Context("Update the Authentication key for the gateway", func() {
-				 It("should successfully clear the auth key", func() {
-					 shouldSkipTest()
-					 authKey, _ := service.NewGatewayPatchTemplateAuthenticationKey("")
-					 gatewayId := os.Getenv("GATEWAY_ID")
+		Context("Update the Authentication key for the gateway", func() {
+			It("should successfully clear the auth key", func() {
+				shouldSkipTest()
+				gatewayId := os.Getenv("GATEWAY_ID")
 
-					 updateGatewayOptions := service.NewUpdateGatewayOptions(gatewayId).SetAuthenticationKey(authKey)
-					 res, resp, err := service.UpdateGateway(updateGatewayOptions)
-					 Expect(err).To(BeNil())
-					 Expect(resp.StatusCode).To(Equal(200))
+				// Fix: Instead of an empty map, provide an object with an empty CRN string.
+				// This is the standard pattern for clearing BGP MD5 keys in IBM Direct Link.
+				patchMap := map[string]interface{}{
+					"authentication_key": map[string]interface{}{
+						"crn": "",
+					},
+				}
 
-					 Expect(*res.ID).To(Equal(gatewayId))
-					 Expect(res.AuthenticationKey).To(BeNil())
-					 Expect(*res.Name).To(Equal(gatewayName))
-				 })
-			 })
+				updateGatewayOptions := service.NewUpdateGatewayOptions(gatewayId, patchMap)
 
-			 Context("Delete a gateway", func() {
-				 It("Successfully deletes a gateway", func() {
-					 shouldSkipTest()
+				res, resp, err := service.UpdateGateway(updateGatewayOptions)
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
 
-					 gatewayId := os.Getenv("GATEWAY_ID")
-					 deteleGatewayOptions := service.NewDeleteGatewayOptions(gatewayId)
+				Expect(*res.ID).To(Equal(gatewayId))
+				Expect(res.AuthenticationKey).To(BeNil())
+				Expect(*res.Name).To(Equal(gatewayName))
 
-					 detailedResponse, err := service.DeleteGateway(deteleGatewayOptions)
-					 Expect(err).To(BeNil())
-					 Expect(detailedResponse.StatusCode).To(Equal(204))
-				 })
-			 })
-		 })
-	*/
+			})
+		})
+
+		Context("Delete a gateway", func() {
+			It("Successfully deletes a gateway", func() {
+				shouldSkipTest()
+
+				gatewayId := os.Getenv("GATEWAY_ID")
+				deteleGatewayOptions := service.NewDeleteGatewayOptions(gatewayId)
+
+				detailedResponse, err := service.DeleteGateway(deteleGatewayOptions)
+				Expect(err).To(BeNil())
+				Expect(detailedResponse.StatusCode).To(Equal(204))
+			})
+		})
+	})
+
 	Describe("DLAAS", func() {
 
 		Describe("Create/Verify/update a connect gateway", func() {
@@ -2419,15 +2439,15 @@ var _ = Describe(`DirectLinkV1`, func() {
 		Expect(result).ToNot(BeNil())
 		gatewayID := result.ID
 
-		// Construct HPCS Key Identity
-
-		// Construct an instance of the HpcsKeyIdentity model
-		hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-		hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:staging:public:hs-crypto:us-south:a/3f455c4c574447adbc14bda52f80e62f:b2044455-b89e-4c57-96ae-3f17c092dd31:key:ebc0fbe6-fd7c-4971-b127-71a385c8f602")
+		// Construct HPCS CAK key reference using new SDK model
+		hpcsCakKey, err := service.NewGatewayMacsecCakKeyReferenceHpcsCakKeyReference(
+			"crn:v1:staging:public:hs-crypto:us-south:a/3f455c4c574447adbc14bda52f80e62f:b2044455-b89e-4c57-96ae-3f17c092dd31:key:ebc0fbe6-fd7c-4971-b127-71a385c8f602",
+		)
+		Expect(err).To(BeNil())
 
 		// Construct an instance of the GatewayMacsecCakPrototype model
 		gatewayMacsecCakPrototypeModel := new(directlinkv1.GatewayMacsecCakPrototype)
-		gatewayMacsecCakPrototypeModel.Key = hpcsKeyIdentityModel
+		gatewayMacsecCakPrototypeModel.Key = hpcsCakKey
 		gatewayMacsecCakPrototypeModel.Name = core.StringPtr("AA01")
 		gatewayMacsecCakPrototypeModel.Session = core.StringPtr("primary")
 
@@ -2478,15 +2498,16 @@ var _ = Describe(`DirectLinkV1`, func() {
 			Expect(res).ToNot(BeNil())
 
 			// Create Gateway Macsec CAK
-			// Construct HPCS Key Indetity for create CAK
-			// Construct an instance of the HpcsKeyIdentity model
-			hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-			hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:staging:public:hs-crypto:us-south:a/3f455c4c574447adbc14bda52f80e62f:b2044455-b89e-4c57-96ae-3f17c092dd31:key:6f79b964-229c-45ab-b1d9-47e111cd03f6")
+			// Construct HPCS CAK key reference for fallback CAK using new SDK model
+			hpcsFallbackCakKey, err := service.NewGatewayMacsecCakKeyReferenceHpcsCakKeyReference(
+				"crn:v1:staging:public:hs-crypto:us-south:a/3f455c4c574447adbc14bda52f80e62f:b2044455-b89e-4c57-96ae-3f17c092dd31:key:6f79b964-229c-45ab-b1d9-47e111cd03f6",
+			)
+			Expect(err).To(BeNil())
 
 			// Construct an instance of the CreateGatewayMacsecCakOptions model
 			createGatewayMacsecCakOptionsModel := new(directlinkv1.CreateGatewayMacsecCakOptions)
 			createGatewayMacsecCakOptionsModel.ID = gatewayID
-			createGatewayMacsecCakOptionsModel.Key = hpcsKeyIdentityModel
+			createGatewayMacsecCakOptionsModel.Key = hpcsFallbackCakKey
 			createGatewayMacsecCakOptionsModel.Name = core.StringPtr("BB02")
 			createGatewayMacsecCakOptionsModel.Session = core.StringPtr("fallback")
 			createGatewayMacsecCakOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -2510,10 +2531,15 @@ var _ = Describe(`DirectLinkV1`, func() {
 			Expect(resultCak).ToNot(BeNil())
 
 			// Update Gateway Macsec CAK
+			// Create another HPCS CAK key reference for update
+			hpcsUpdateCakKey, err := service.NewGatewayMacsecCakKeyReferenceHpcsCakKeyReference(
+				"crn:v1:staging:public:hs-crypto:us-south:a/3f455c4c574447adbc14bda52f80e62f:b2044455-b89e-4c57-96ae-3f17c092dd31:key:ebc0fbe6-fd7c-4971-b127-71a385c8f602",
+			)
+			Expect(err).To(BeNil())
 
 			// Construct an instance of the GatewayMacsecCakPatch model
 			gatewayMacsecCakPatchModel := new(directlinkv1.GatewayMacsecCakPatch)
-			gatewayMacsecCakPatchModel.Key = hpcsKeyIdentityModel
+			gatewayMacsecCakPatchModel.Key = hpcsUpdateCakKey
 			gatewayMacsecCakPatchModel.Name = core.StringPtr("AA02")
 			gatewayMacsecCakPatchModelAsPatch, asPatchErr := gatewayMacsecCakPatchModel.AsPatch()
 			Expect(asPatchErr).To(BeNil())

--- a/directlinkv1/direct_link_v1_suite_test.go
+++ b/directlinkv1/direct_link_v1_suite_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2023.
+ * (C) Copyright IBM Corp. 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/directlinkv1/direct_link_v1_test.go
+++ b/directlinkv1/direct_link_v1_test.go
@@ -42,14 +42,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 		It(`Instantiate service client`, func() {
 			directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 				Authenticator: &core.NoAuthAuthenticator{},
-				Version: core.StringPtr(version),
+				Version:       core.StringPtr(version),
 			})
 			Expect(directLinkService).ToNot(BeNil())
 			Expect(serviceErr).To(BeNil())
 		})
 		It(`Instantiate service client with error: Invalid URL`, func() {
 			directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
-				URL: "{BAD_URL_STRING",
+				URL:     "{BAD_URL_STRING",
 				Version: core.StringPtr(version),
 			})
 			Expect(directLinkService).To(BeNil())
@@ -57,7 +57,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 		})
 		It(`Instantiate service client with error: Invalid Auth`, func() {
 			directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
-				URL: "https://directlinkv1/api",
+				URL:     "https://directlinkv1/api",
 				Version: core.StringPtr(version),
 				Authenticator: &core.BasicAuthenticator{
 					Username: "",
@@ -78,7 +78,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 		Context(`Using external config, construct service client instances`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"DIRECT_LINK_URL": "https://directlinkv1/api",
+				"DIRECT_LINK_URL":       "https://directlinkv1/api",
 				"DIRECT_LINK_AUTH_TYPE": "noauth",
 			}
 
@@ -100,7 +100,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 			It(`Create service client using external config and set url from constructor successfully`, func() {
 				SetTestEnvironment(testEnvironment)
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1UsingExternalConfig(&directlinkv1.DirectLinkV1Options{
-					URL: "https://testService/api",
+					URL:     "https://testService/api",
 					Version: core.StringPtr(version),
 				})
 				Expect(directLinkService).ToNot(BeNil())
@@ -136,7 +136,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid Auth`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"DIRECT_LINK_URL": "https://directlinkv1/api",
+				"DIRECT_LINK_URL":       "https://directlinkv1/api",
 				"DIRECT_LINK_AUTH_TYPE": "someOtherAuth",
 			}
 
@@ -154,12 +154,12 @@ var _ = Describe(`DirectLinkV1`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid URL`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"DIRECT_LINK_AUTH_TYPE":   "NOAuth",
+				"DIRECT_LINK_AUTH_TYPE": "NOAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
 			directLinkService, serviceErr := directlinkv1.NewDirectLinkV1UsingExternalConfig(&directlinkv1.DirectLinkV1Options{
-				URL: "{BAD_URL_STRING",
+				URL:     "{BAD_URL_STRING",
 				Version: core.StringPtr(version),
 			})
 
@@ -201,7 +201,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -253,7 +253,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -308,7 +308,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -334,7 +334,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -368,7 +368,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -411,7 +411,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -559,7 +559,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -710,7 +710,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -816,7 +816,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -937,7 +937,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1059,7 +1059,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1083,7 +1083,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1132,7 +1132,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1185,7 +1185,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1241,7 +1241,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1268,7 +1268,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1310,7 +1310,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1354,7 +1354,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1454,7 +1454,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1557,7 +1557,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1615,7 +1615,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1688,7 +1688,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1763,7 +1763,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1876,7 +1876,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1992,7 +1992,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2063,7 +2063,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2149,7 +2149,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2242,7 +2242,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2298,7 +2298,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2325,7 +2325,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2367,7 +2367,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2381,7 +2381,6 @@ var _ = Describe(`DirectLinkV1`, func() {
 				result, response, operationErr := directLinkService.ListGatewayCompletionNotice(listGatewayCompletionNoticeOptionsModel)
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
-
 
 				// Verify empty byte buffer.
 				Expect(result).ToNot(BeNil())
@@ -2415,7 +2414,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2439,9 +2438,9 @@ var _ = Describe(`DirectLinkV1`, func() {
 			})
 			It(`Invoke CreateGatewayCompletionNotice with error: Param validation error`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
-					URL:  testServer.URL,
+					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2457,7 +2456,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2513,7 +2512,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2569,7 +2568,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2596,7 +2595,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2638,7 +2637,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2652,7 +2651,6 @@ var _ = Describe(`DirectLinkV1`, func() {
 				result, response, operationErr := directLinkService.ListGatewayLetterOfAuthorization(listGatewayLetterOfAuthorizationOptionsModel)
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
-
 
 				// Verify empty byte buffer.
 				Expect(result).ToNot(BeNil())
@@ -2688,7 +2686,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2743,7 +2741,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2801,7 +2799,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2829,7 +2827,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2872,7 +2870,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2918,7 +2916,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2973,7 +2971,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3031,7 +3029,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3059,7 +3057,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3102,7 +3100,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3147,7 +3145,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3200,7 +3198,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3256,7 +3254,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3283,7 +3281,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3325,7 +3323,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3371,7 +3369,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3450,7 +3448,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3532,7 +3530,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3567,7 +3565,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3617,7 +3615,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3669,7 +3667,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3722,7 +3720,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3778,7 +3776,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3805,7 +3803,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3847,7 +3845,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3891,7 +3889,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3965,7 +3963,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4042,7 +4040,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4074,7 +4072,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4121,7 +4119,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4172,7 +4170,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4252,7 +4250,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4335,7 +4333,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4371,7 +4369,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4422,7 +4420,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4474,7 +4472,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4499,7 +4497,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4549,7 +4547,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4603,7 +4601,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4660,7 +4658,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4688,7 +4686,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4731,7 +4729,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4776,7 +4774,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4857,7 +4855,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4941,7 +4939,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4980,7 +4978,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5034,7 +5032,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5090,7 +5088,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5143,7 +5141,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5199,7 +5197,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5226,7 +5224,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5268,7 +5266,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5312,7 +5310,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5386,7 +5384,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5463,7 +5461,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5495,7 +5493,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5542,7 +5540,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5593,7 +5591,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5673,7 +5671,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5756,7 +5754,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5792,7 +5790,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5843,7 +5841,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5895,7 +5893,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5920,7 +5918,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5970,7 +5968,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6024,7 +6022,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6081,7 +6079,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6109,7 +6107,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6152,7 +6150,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6197,7 +6195,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6278,7 +6276,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6362,7 +6360,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6401,7 +6399,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6455,7 +6453,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6510,7 +6508,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6534,7 +6532,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6583,7 +6581,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6636,7 +6634,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6692,7 +6690,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6719,7 +6717,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6761,7 +6759,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6805,7 +6803,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6889,7 +6887,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6976,7 +6974,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7018,7 +7016,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7075,7 +7073,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7136,7 +7134,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7228,7 +7226,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7323,7 +7321,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7371,7 +7369,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7434,7 +7432,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7499,7 +7497,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7552,7 +7550,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7608,7 +7606,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7635,7 +7633,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7677,7 +7675,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7721,7 +7719,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7797,7 +7795,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7876,7 +7874,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7910,7 +7908,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7959,7 +7957,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8009,7 +8007,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8034,7 +8032,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8084,7 +8082,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8138,7 +8136,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8195,7 +8193,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8223,7 +8221,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8266,7 +8264,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8311,7 +8309,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8393,7 +8391,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8478,7 +8476,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8518,7 +8516,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8573,7 +8571,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8630,7 +8628,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8683,7 +8681,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8739,7 +8737,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8766,7 +8764,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8808,7 +8806,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8852,7 +8850,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8905,7 +8903,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8961,7 +8959,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8988,7 +8986,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9030,7 +9028,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9073,7 +9071,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9098,7 +9096,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9148,7 +9146,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9202,7 +9200,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9259,7 +9257,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9287,7 +9285,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9330,7 +9328,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9375,7 +9373,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9428,7 +9426,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9484,7 +9482,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9511,7 +9509,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9553,7 +9551,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9597,7 +9595,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9669,7 +9667,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9744,7 +9742,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9774,7 +9772,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9819,7 +9817,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9865,7 +9863,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9890,7 +9888,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9940,7 +9938,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9994,7 +9992,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10051,7 +10049,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10079,7 +10077,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10122,7 +10120,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10167,7 +10165,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10245,7 +10243,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10326,7 +10324,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10362,7 +10360,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10413,7 +10411,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10466,7 +10464,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10519,7 +10517,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10575,7 +10573,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10602,7 +10600,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10644,7 +10642,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10688,7 +10686,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10742,7 +10740,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10799,7 +10797,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10827,7 +10825,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10870,7 +10868,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10915,7 +10913,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10968,7 +10966,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11024,7 +11022,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11051,7 +11049,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11093,7 +11091,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11140,7 +11138,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11198,7 +11196,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11259,7 +11257,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11288,7 +11286,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11325,7 +11323,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11395,13 +11393,13 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 
 				listPortsOptionsModel := &directlinkv1.ListPortsOptions{
-					Limit: core.Int64Ptr(int64(10)),
+					Limit:        core.Int64Ptr(int64(10)),
 					LocationName: core.StringPtr("testString"),
 				}
 
@@ -11422,13 +11420,13 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 
 				listPortsOptionsModel := &directlinkv1.ListPortsOptions{
-					Limit: core.Int64Ptr(int64(10)),
+					Limit:        core.Int64Ptr(int64(10)),
 					LocationName: core.StringPtr("testString"),
 				}
 
@@ -11464,7 +11462,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11517,7 +11515,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11573,7 +11571,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11600,7 +11598,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11642,7 +11640,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version: core.StringPtr(version),
+					Version:       core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11671,7 +11669,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 			directLinkService, _ := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 				URL:           "http://directlinkv1modelgenerator.com",
 				Authenticator: &core.NoAuthAuthenticator{},
-				Version: core.StringPtr(version),
+				Version:       core.StringPtr(version),
 			})
 			It(`Invoke NewAsPrependPrefixArrayTemplate successfully`, func() {
 				length := int64(4)

--- a/directlinkv1/direct_link_v1_test.go
+++ b/directlinkv1/direct_link_v1_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2024.
+ * (C) Copyright IBM Corp. 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,15 +42,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 		It(`Instantiate service client`, func() {
 			directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 				Authenticator: &core.NoAuthAuthenticator{},
-				Version:       core.StringPtr(version),
-				ServiceName:   "dl_services",
+				Version: core.StringPtr(version),
 			})
 			Expect(directLinkService).ToNot(BeNil())
 			Expect(serviceErr).To(BeNil())
 		})
 		It(`Instantiate service client with error: Invalid URL`, func() {
 			directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
-				URL:     "{BAD_URL_STRING",
+				URL: "{BAD_URL_STRING",
 				Version: core.StringPtr(version),
 			})
 			Expect(directLinkService).To(BeNil())
@@ -58,7 +57,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 		})
 		It(`Instantiate service client with error: Invalid Auth`, func() {
 			directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
-				URL:     "https://directlinkv1/api",
+				URL: "https://directlinkv1/api",
 				Version: core.StringPtr(version),
 				Authenticator: &core.BasicAuthenticator{
 					Username: "",
@@ -79,7 +78,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 		Context(`Using external config, construct service client instances`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"DIRECT_LINK_URL":       "https://directlinkv1/api",
+				"DIRECT_LINK_URL": "https://directlinkv1/api",
 				"DIRECT_LINK_AUTH_TYPE": "noauth",
 			}
 
@@ -101,7 +100,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 			It(`Create service client using external config and set url from constructor successfully`, func() {
 				SetTestEnvironment(testEnvironment)
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1UsingExternalConfig(&directlinkv1.DirectLinkV1Options{
-					URL:     "https://testService/api",
+					URL: "https://testService/api",
 					Version: core.StringPtr(version),
 				})
 				Expect(directLinkService).ToNot(BeNil())
@@ -137,7 +136,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid Auth`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"DIRECT_LINK_URL":       "https://directlinkv1/api",
+				"DIRECT_LINK_URL": "https://directlinkv1/api",
 				"DIRECT_LINK_AUTH_TYPE": "someOtherAuth",
 			}
 
@@ -155,12 +154,12 @@ var _ = Describe(`DirectLinkV1`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid URL`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"DIRECT_LINK_AUTH_TYPE": "NOAuth",
+				"DIRECT_LINK_AUTH_TYPE":   "NOAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
 			directLinkService, serviceErr := directlinkv1.NewDirectLinkV1UsingExternalConfig(&directlinkv1.DirectLinkV1Options{
-				URL:     "{BAD_URL_STRING",
+				URL: "{BAD_URL_STRING",
 				Version: core.StringPtr(version),
 			})
 
@@ -202,7 +201,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -247,14 +246,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"gateways": [{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:kms:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}]}`)
+					fmt.Fprintf(res, "%s", `{"gateways": [{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}]}`)
 				}))
 			})
 			It(`Invoke ListGateways successfully with retries`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -302,14 +301,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"gateways": [{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:kms:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}]}`)
+					fmt.Fprintf(res, "%s", `{"gateways": [{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}]}`)
 				}))
 			})
 			It(`Invoke ListGateways successfully`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -335,7 +334,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -369,7 +368,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -412,7 +411,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -444,13 +443,13 @@ var _ = Describe(`DirectLinkV1`, func() {
 				resourceGroupIdentityModel := new(directlinkv1.ResourceGroupIdentity)
 				resourceGroupIdentityModel.ID = core.StringPtr("56969d6043e9465c883cb9f7363e78e8")
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the GatewayMacsecCakPrototype model
 				gatewayMacsecCakPrototypeModel := new(directlinkv1.GatewayMacsecCakPrototype)
-				gatewayMacsecCakPrototypeModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPrototypeModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPrototypeModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPrototypeModel.Session = core.StringPtr("primary")
 
@@ -553,14 +552,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:kms:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
+					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
 				}))
 			})
 			It(`Invoke CreateGateway successfully with retries`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -593,13 +592,13 @@ var _ = Describe(`DirectLinkV1`, func() {
 				resourceGroupIdentityModel := new(directlinkv1.ResourceGroupIdentity)
 				resourceGroupIdentityModel.ID = core.StringPtr("56969d6043e9465c883cb9f7363e78e8")
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the GatewayMacsecCakPrototype model
 				gatewayMacsecCakPrototypeModel := new(directlinkv1.GatewayMacsecCakPrototype)
-				gatewayMacsecCakPrototypeModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPrototypeModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPrototypeModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPrototypeModel.Session = core.StringPtr("primary")
 
@@ -704,14 +703,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:kms:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
+					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
 				}))
 			})
 			It(`Invoke CreateGateway successfully`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -749,13 +748,13 @@ var _ = Describe(`DirectLinkV1`, func() {
 				resourceGroupIdentityModel := new(directlinkv1.ResourceGroupIdentity)
 				resourceGroupIdentityModel.ID = core.StringPtr("56969d6043e9465c883cb9f7363e78e8")
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the GatewayMacsecCakPrototype model
 				gatewayMacsecCakPrototypeModel := new(directlinkv1.GatewayMacsecCakPrototype)
-				gatewayMacsecCakPrototypeModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPrototypeModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPrototypeModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPrototypeModel.Session = core.StringPtr("primary")
 
@@ -817,7 +816,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -849,13 +848,13 @@ var _ = Describe(`DirectLinkV1`, func() {
 				resourceGroupIdentityModel := new(directlinkv1.ResourceGroupIdentity)
 				resourceGroupIdentityModel.ID = core.StringPtr("56969d6043e9465c883cb9f7363e78e8")
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the GatewayMacsecCakPrototype model
 				gatewayMacsecCakPrototypeModel := new(directlinkv1.GatewayMacsecCakPrototype)
-				gatewayMacsecCakPrototypeModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPrototypeModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPrototypeModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPrototypeModel.Session = core.StringPtr("primary")
 
@@ -938,7 +937,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -970,13 +969,13 @@ var _ = Describe(`DirectLinkV1`, func() {
 				resourceGroupIdentityModel := new(directlinkv1.ResourceGroupIdentity)
 				resourceGroupIdentityModel.ID = core.StringPtr("56969d6043e9465c883cb9f7363e78e8")
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the GatewayMacsecCakPrototype model
 				gatewayMacsecCakPrototypeModel := new(directlinkv1.GatewayMacsecCakPrototype)
-				gatewayMacsecCakPrototypeModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPrototypeModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPrototypeModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPrototypeModel.Session = core.StringPtr("primary")
 
@@ -1060,7 +1059,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1084,7 +1083,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1133,7 +1132,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1179,14 +1178,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:kms:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
+					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
 				}))
 			})
 			It(`Invoke GetGateway successfully with retries`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1235,14 +1234,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:kms:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
+					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
 				}))
 			})
 			It(`Invoke GetGateway successfully`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1269,7 +1268,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1311,7 +1310,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1355,7 +1354,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1448,14 +1447,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:kms:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
+					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
 				}))
 			})
 			It(`Invoke UpdateGateway successfully with retries`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1551,14 +1550,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:kms:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
+					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
 				}))
 			})
 			It(`Invoke UpdateGateway successfully`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1616,7 +1615,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1689,7 +1688,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1764,7 +1763,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1870,14 +1869,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:kms:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
+					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
 				}))
 			})
 			It(`Invoke CreateGatewayAction successfully with retries`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -1986,14 +1985,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:kms:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
+					fmt.Fprintf(res, "%s", `{"as_prepends": [{"created_at": "2019-01-01T12:00:00.000Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "length": 4, "policy": "import", "prefix": "172.17.0.0/16", "specific_prefixes": ["192.168.3.0/24"], "updated_at": "2019-01-01T12:00:00.000Z"}], "authentication_key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "bfd_config": {"bfd_status": "up", "bfd_status_updated_at": "2020-08-20T06:58:41.909Z", "interval": 2000, "multiplier": 10}, "bgp_asn": 64999, "bgp_base_cidr": "BgpBaseCidr", "bgp_cer_cidr": "10.254.30.78/30", "bgp_ibm_asn": 13884, "bgp_ibm_cidr": "10.254.30.77/30", "bgp_status": "active", "bgp_status_updated_at": "2020-08-20T06:58:41.909Z", "carrier_name": "myCarrierName", "change_request": {"type": "create_gateway"}, "completion_notice_reject_reason": "The completion notice file was blank", "connection_mode": "transit", "created_at": "2019-01-01T12:00:00.000Z", "crn": "crn:v1:bluemix:public:directlink:dal03:a/4111d05f36894e3cb9b46a43556d9000::dedicated:ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "cross_account": false, "cross_connect_router": "xcr01.dal03", "customer_name": "newCustomerName", "default_export_route_filter": "permit", "default_import_route_filter": "permit", "global": true, "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "link_status": "up", "link_status_updated_at": "2020-08-20T06:58:41.909Z", "location_display_name": "Dallas 03", "location_name": "dal03", "macsec": {"active": true, "security_policy": "must_secure", "status": "secured", "status_reasons": [{"code": "macsec_cak_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}]}, "macsec_capability": "non_macsec", "metered": false, "name": "myGateway", "operational_status": "awaiting_completion_notice", "operational_status_reasons": [{"code": "authentication_key_failed", "message": "The authentication_key failed configuration.", "more_info": "https://cloud.ibm.com/docs/dl/TODO_ADD_DOCS_LINK"}], "patch_panel_completion_notice": "patch panel configuration details", "port": {"id": "54321b1a-fee4-41c7-9e11-9cd99e000aaa"}, "provider_api_managed": false, "resource_group": {"id": "56969d6043e9465c883cb9f7363e78e8"}, "speed_mbps": 1000, "type": "dedicated", "vlan": 10}`)
 				}))
 			})
 			It(`Invoke CreateGatewayAction successfully`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2064,7 +2063,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2150,7 +2149,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2243,7 +2242,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2299,7 +2298,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2326,7 +2325,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2368,7 +2367,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2382,6 +2381,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				result, response, operationErr := directLinkService.ListGatewayCompletionNotice(listGatewayCompletionNoticeOptionsModel)
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
+
 
 				// Verify empty byte buffer.
 				Expect(result).ToNot(BeNil())
@@ -2415,7 +2415,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2439,9 +2439,9 @@ var _ = Describe(`DirectLinkV1`, func() {
 			})
 			It(`Invoke CreateGatewayCompletionNotice with error: Param validation error`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
-					URL:           testServer.URL,
+					URL:  testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2457,7 +2457,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2513,7 +2513,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2569,7 +2569,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2596,7 +2596,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2638,7 +2638,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2652,6 +2652,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				result, response, operationErr := directLinkService.ListGatewayLetterOfAuthorization(listGatewayLetterOfAuthorizationOptionsModel)
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
+
 
 				// Verify empty byte buffer.
 				Expect(result).ToNot(BeNil())
@@ -2687,7 +2688,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2742,7 +2743,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2800,7 +2801,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2828,7 +2829,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2871,7 +2872,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2917,7 +2918,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -2972,7 +2973,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3030,7 +3031,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3058,7 +3059,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3101,7 +3102,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3146,7 +3147,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3199,7 +3200,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3255,7 +3256,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3282,7 +3283,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3324,7 +3325,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3370,7 +3371,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3449,7 +3450,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3531,7 +3532,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3566,7 +3567,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3616,7 +3617,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3668,7 +3669,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3721,7 +3722,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3777,7 +3778,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3804,7 +3805,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3846,7 +3847,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3890,7 +3891,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -3964,7 +3965,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4041,7 +4042,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4073,7 +4074,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4120,7 +4121,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4171,7 +4172,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4251,7 +4252,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4334,7 +4335,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4370,7 +4371,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4421,7 +4422,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4473,7 +4474,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4498,7 +4499,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4548,7 +4549,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4602,7 +4603,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4659,7 +4660,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4687,7 +4688,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4730,7 +4731,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4775,7 +4776,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4856,7 +4857,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4940,7 +4941,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -4979,7 +4980,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5033,7 +5034,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5089,7 +5090,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5142,7 +5143,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5198,7 +5199,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5225,7 +5226,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5267,7 +5268,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5311,7 +5312,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5385,7 +5386,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5462,7 +5463,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5494,7 +5495,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5541,7 +5542,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5592,7 +5593,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5672,7 +5673,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5755,7 +5756,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5791,7 +5792,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5842,7 +5843,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5894,7 +5895,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5919,7 +5920,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -5969,7 +5970,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6023,7 +6024,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6080,7 +6081,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6108,7 +6109,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6151,7 +6152,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6196,7 +6197,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6277,7 +6278,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6361,7 +6362,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6400,7 +6401,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6454,7 +6455,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6509,7 +6510,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6533,7 +6534,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6582,7 +6583,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6635,7 +6636,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6691,7 +6692,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6718,7 +6719,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6760,7 +6761,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6804,7 +6805,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6888,7 +6889,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -6975,7 +6976,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7017,7 +7018,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7074,7 +7075,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7135,18 +7136,18 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the GatewayMacsecCakPrototype model
 				gatewayMacsecCakPrototypeModel := new(directlinkv1.GatewayMacsecCakPrototype)
-				gatewayMacsecCakPrototypeModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPrototypeModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPrototypeModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPrototypeModel.Session = core.StringPtr("primary")
 
@@ -7227,19 +7228,19 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 				directLinkService.EnableRetries(0, 0)
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the GatewayMacsecCakPrototype model
 				gatewayMacsecCakPrototypeModel := new(directlinkv1.GatewayMacsecCakPrototype)
-				gatewayMacsecCakPrototypeModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPrototypeModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPrototypeModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPrototypeModel.Session = core.StringPtr("primary")
 
@@ -7322,7 +7323,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7333,13 +7334,13 @@ var _ = Describe(`DirectLinkV1`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the GatewayMacsecCakPrototype model
 				gatewayMacsecCakPrototypeModel := new(directlinkv1.GatewayMacsecCakPrototype)
-				gatewayMacsecCakPrototypeModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPrototypeModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPrototypeModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPrototypeModel.Session = core.StringPtr("primary")
 
@@ -7370,18 +7371,18 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the GatewayMacsecCakPrototype model
 				gatewayMacsecCakPrototypeModel := new(directlinkv1.GatewayMacsecCakPrototype)
-				gatewayMacsecCakPrototypeModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPrototypeModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPrototypeModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPrototypeModel.Session = core.StringPtr("primary")
 
@@ -7433,18 +7434,18 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the GatewayMacsecCakPrototype model
 				gatewayMacsecCakPrototypeModel := new(directlinkv1.GatewayMacsecCakPrototype)
-				gatewayMacsecCakPrototypeModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPrototypeModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPrototypeModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPrototypeModel.Session = core.StringPtr("primary")
 
@@ -7498,7 +7499,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7544,14 +7545,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"caks": [{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}]}`)
+					fmt.Fprintf(res, "%s", `{"caks": [{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "status": "active"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}]}`)
 				}))
 			})
 			It(`Invoke ListGatewayMacsecCaks successfully with retries`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7600,14 +7601,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"caks": [{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}]}`)
+					fmt.Fprintf(res, "%s", `{"caks": [{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "status": "active"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}]}`)
 				}))
 			})
 			It(`Invoke ListGatewayMacsecCaks successfully`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7634,7 +7635,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7676,7 +7677,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7720,19 +7721,19 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the CreateGatewayMacsecCakOptions model
 				createGatewayMacsecCakOptionsModel := new(directlinkv1.CreateGatewayMacsecCakOptions)
 				createGatewayMacsecCakOptionsModel.ID = core.StringPtr("0a06fb9b-820f-4c44-8a31-77f1f0806d28")
-				createGatewayMacsecCakOptionsModel.Key = hpcsKeyIdentityModel
+				createGatewayMacsecCakOptionsModel.Key = gatewayMacsecCakKeyReferenceModel
 				createGatewayMacsecCakOptionsModel.Name = core.StringPtr("1000")
 				createGatewayMacsecCakOptionsModel.Session = core.StringPtr("primary")
 				createGatewayMacsecCakOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -7789,27 +7790,27 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}`)
+					fmt.Fprintf(res, "%s", `{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "status": "active"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}`)
 				}))
 			})
 			It(`Invoke CreateGatewayMacsecCak successfully with retries`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 				directLinkService.EnableRetries(0, 0)
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the CreateGatewayMacsecCakOptions model
 				createGatewayMacsecCakOptionsModel := new(directlinkv1.CreateGatewayMacsecCakOptions)
 				createGatewayMacsecCakOptionsModel.ID = core.StringPtr("0a06fb9b-820f-4c44-8a31-77f1f0806d28")
-				createGatewayMacsecCakOptionsModel.Key = hpcsKeyIdentityModel
+				createGatewayMacsecCakOptionsModel.Key = gatewayMacsecCakKeyReferenceModel
 				createGatewayMacsecCakOptionsModel.Name = core.StringPtr("1000")
 				createGatewayMacsecCakOptionsModel.Session = core.StringPtr("primary")
 				createGatewayMacsecCakOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -7868,14 +7869,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}`)
+					fmt.Fprintf(res, "%s", `{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "status": "active"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}`)
 				}))
 			})
 			It(`Invoke CreateGatewayMacsecCak successfully`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -7886,14 +7887,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the CreateGatewayMacsecCakOptions model
 				createGatewayMacsecCakOptionsModel := new(directlinkv1.CreateGatewayMacsecCakOptions)
 				createGatewayMacsecCakOptionsModel.ID = core.StringPtr("0a06fb9b-820f-4c44-8a31-77f1f0806d28")
-				createGatewayMacsecCakOptionsModel.Key = hpcsKeyIdentityModel
+				createGatewayMacsecCakOptionsModel.Key = gatewayMacsecCakKeyReferenceModel
 				createGatewayMacsecCakOptionsModel.Name = core.StringPtr("1000")
 				createGatewayMacsecCakOptionsModel.Session = core.StringPtr("primary")
 				createGatewayMacsecCakOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -7909,19 +7910,19 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the CreateGatewayMacsecCakOptions model
 				createGatewayMacsecCakOptionsModel := new(directlinkv1.CreateGatewayMacsecCakOptions)
 				createGatewayMacsecCakOptionsModel.ID = core.StringPtr("0a06fb9b-820f-4c44-8a31-77f1f0806d28")
-				createGatewayMacsecCakOptionsModel.Key = hpcsKeyIdentityModel
+				createGatewayMacsecCakOptionsModel.Key = gatewayMacsecCakKeyReferenceModel
 				createGatewayMacsecCakOptionsModel.Name = core.StringPtr("1000")
 				createGatewayMacsecCakOptionsModel.Session = core.StringPtr("primary")
 				createGatewayMacsecCakOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -7958,19 +7959,19 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the CreateGatewayMacsecCakOptions model
 				createGatewayMacsecCakOptionsModel := new(directlinkv1.CreateGatewayMacsecCakOptions)
 				createGatewayMacsecCakOptionsModel.ID = core.StringPtr("0a06fb9b-820f-4c44-8a31-77f1f0806d28")
-				createGatewayMacsecCakOptionsModel.Key = hpcsKeyIdentityModel
+				createGatewayMacsecCakOptionsModel.Key = gatewayMacsecCakKeyReferenceModel
 				createGatewayMacsecCakOptionsModel.Name = core.StringPtr("1000")
 				createGatewayMacsecCakOptionsModel.Session = core.StringPtr("primary")
 				createGatewayMacsecCakOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -8008,7 +8009,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8033,7 +8034,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8083,7 +8084,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8130,14 +8131,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}`)
+					fmt.Fprintf(res, "%s", `{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "status": "active"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}`)
 				}))
 			})
 			It(`Invoke GetGatewayMacsecCak successfully with retries`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8187,14 +8188,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}`)
+					fmt.Fprintf(res, "%s", `{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "status": "active"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}`)
 				}))
 			})
 			It(`Invoke GetGatewayMacsecCak successfully`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8222,7 +8223,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8265,7 +8266,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8310,18 +8311,18 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the GatewayMacsecCakPatch model
 				gatewayMacsecCakPatchModel := new(directlinkv1.GatewayMacsecCakPatch)
-				gatewayMacsecCakPatchModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPatchModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPatchModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPatchModelAsPatch, asPatchErr := gatewayMacsecCakPatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -8385,26 +8386,26 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}`)
+					fmt.Fprintf(res, "%s", `{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "status": "active"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}`)
 				}))
 			})
 			It(`Invoke UpdateGatewayMacsecCak successfully with retries`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 				directLinkService.EnableRetries(0, 0)
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the GatewayMacsecCakPatch model
 				gatewayMacsecCakPatchModel := new(directlinkv1.GatewayMacsecCakPatch)
-				gatewayMacsecCakPatchModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPatchModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPatchModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPatchModelAsPatch, asPatchErr := gatewayMacsecCakPatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -8470,14 +8471,14 @@ var _ = Describe(`DirectLinkV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}`)
+					fmt.Fprintf(res, "%s", `{"active_delta": {"key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "status": "active"}, "created_at": "2020-11-02T20:40:29.622Z", "id": "ef4dcb1a-fee4-41c7-9e11-9cd99e65c1f4", "key": {"crn": "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"}, "name": "1000", "session": "primary", "status": "active", "updated_at": "2020-11-02T20:40:29.622Z"}`)
 				}))
 			})
 			It(`Invoke UpdateGatewayMacsecCak successfully`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8488,13 +8489,13 @@ var _ = Describe(`DirectLinkV1`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the GatewayMacsecCakPatch model
 				gatewayMacsecCakPatchModel := new(directlinkv1.GatewayMacsecCakPatch)
-				gatewayMacsecCakPatchModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPatchModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPatchModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPatchModelAsPatch, asPatchErr := gatewayMacsecCakPatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -8517,18 +8518,18 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the GatewayMacsecCakPatch model
 				gatewayMacsecCakPatchModel := new(directlinkv1.GatewayMacsecCakPatch)
-				gatewayMacsecCakPatchModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPatchModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPatchModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPatchModelAsPatch, asPatchErr := gatewayMacsecCakPatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -8572,18 +8573,18 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
 
 				// Construct an instance of the GatewayMacsecCakPatch model
 				gatewayMacsecCakPatchModel := new(directlinkv1.GatewayMacsecCakPatch)
-				gatewayMacsecCakPatchModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPatchModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPatchModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPatchModelAsPatch, asPatchErr := gatewayMacsecCakPatchModel.AsPatch()
 				Expect(asPatchErr).To(BeNil())
@@ -8629,7 +8630,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8682,7 +8683,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8738,7 +8739,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8765,7 +8766,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8807,7 +8808,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8851,7 +8852,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8904,7 +8905,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8960,7 +8961,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -8987,7 +8988,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9029,7 +9030,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9072,7 +9073,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9097,7 +9098,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9147,7 +9148,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9201,7 +9202,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9258,7 +9259,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9286,7 +9287,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9329,7 +9330,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9374,7 +9375,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9427,7 +9428,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9483,7 +9484,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9510,7 +9511,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9552,7 +9553,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9596,7 +9597,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9668,7 +9669,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9743,7 +9744,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9773,7 +9774,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9818,7 +9819,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9864,7 +9865,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9889,7 +9890,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9939,7 +9940,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -9993,7 +9994,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10050,7 +10051,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10078,7 +10079,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10121,7 +10122,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10166,7 +10167,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10244,7 +10245,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10325,7 +10326,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10361,7 +10362,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10412,7 +10413,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10465,7 +10466,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10518,7 +10519,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10574,7 +10575,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10601,7 +10602,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10643,7 +10644,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10687,7 +10688,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10741,7 +10742,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10798,7 +10799,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10826,7 +10827,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10869,7 +10870,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10914,7 +10915,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -10967,7 +10968,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11023,7 +11024,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11050,7 +11051,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11092,7 +11093,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11139,7 +11140,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11197,7 +11198,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11258,7 +11259,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11287,7 +11288,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11324,7 +11325,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11394,13 +11395,13 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 
 				listPortsOptionsModel := &directlinkv1.ListPortsOptions{
-					Limit:        core.Int64Ptr(int64(10)),
+					Limit: core.Int64Ptr(int64(10)),
 					LocationName: core.StringPtr("testString"),
 				}
 
@@ -11421,13 +11422,13 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
 
 				listPortsOptionsModel := &directlinkv1.ListPortsOptions{
-					Limit:        core.Int64Ptr(int64(10)),
+					Limit: core.Int64Ptr(int64(10)),
 					LocationName: core.StringPtr("testString"),
 				}
 
@@ -11463,7 +11464,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11516,7 +11517,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11572,7 +11573,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11599,7 +11600,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11641,7 +11642,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				directLinkService, serviceErr := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Version:       core.StringPtr(version),
+					Version: core.StringPtr(version),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(directLinkService).ToNot(BeNil())
@@ -11670,7 +11671,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 			directLinkService, _ := directlinkv1.NewDirectLinkV1(&directlinkv1.DirectLinkV1Options{
 				URL:           "http://directlinkv1modelgenerator.com",
 				Authenticator: &core.NoAuthAuthenticator{},
-				Version:       core.StringPtr(version),
+				Version: core.StringPtr(version),
 			})
 			It(`Invoke NewAsPrependPrefixArrayTemplate successfully`, func() {
 				length := int64(4)
@@ -11831,26 +11832,26 @@ var _ = Describe(`DirectLinkV1`, func() {
 				Expect(createGatewayImportRouteFilterOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewCreateGatewayMacsecCakOptions successfully`, func() {
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				Expect(hpcsKeyIdentityModel).ToNot(BeNil())
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
-				Expect(hpcsKeyIdentityModel.Crn).To(Equal(core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")))
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				Expect(gatewayMacsecCakKeyReferenceModel).ToNot(BeNil())
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				Expect(gatewayMacsecCakKeyReferenceModel.Crn).To(Equal(core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")))
 
 				// Construct an instance of the CreateGatewayMacsecCakOptions model
 				id := "0a06fb9b-820f-4c44-8a31-77f1f0806d28"
-				var createGatewayMacsecCakOptionsKey *directlinkv1.HpcsKeyIdentity = nil
+				var createGatewayMacsecCakOptionsKey directlinkv1.GatewayMacsecCakKeyReferenceIntf = nil
 				createGatewayMacsecCakOptionsName := "1000"
 				createGatewayMacsecCakOptionsSession := "primary"
 				createGatewayMacsecCakOptionsModel := directLinkService.NewCreateGatewayMacsecCakOptions(id, createGatewayMacsecCakOptionsKey, createGatewayMacsecCakOptionsName, createGatewayMacsecCakOptionsSession)
 				createGatewayMacsecCakOptionsModel.SetID("0a06fb9b-820f-4c44-8a31-77f1f0806d28")
-				createGatewayMacsecCakOptionsModel.SetKey(hpcsKeyIdentityModel)
+				createGatewayMacsecCakOptionsModel.SetKey(gatewayMacsecCakKeyReferenceModel)
 				createGatewayMacsecCakOptionsModel.SetName("1000")
 				createGatewayMacsecCakOptionsModel.SetSession("primary")
 				createGatewayMacsecCakOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createGatewayMacsecCakOptionsModel).ToNot(BeNil())
 				Expect(createGatewayMacsecCakOptionsModel.ID).To(Equal(core.StringPtr("0a06fb9b-820f-4c44-8a31-77f1f0806d28")))
-				Expect(createGatewayMacsecCakOptionsModel.Key).To(Equal(hpcsKeyIdentityModel))
+				Expect(createGatewayMacsecCakOptionsModel.Key).To(Equal(gatewayMacsecCakKeyReferenceModel))
 				Expect(createGatewayMacsecCakOptionsModel.Name).To(Equal(core.StringPtr("1000")))
 				Expect(createGatewayMacsecCakOptionsModel.Session).To(Equal(core.StringPtr("primary")))
 				Expect(createGatewayMacsecCakOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
@@ -11900,19 +11901,19 @@ var _ = Describe(`DirectLinkV1`, func() {
 				resourceGroupIdentityModel.ID = core.StringPtr("56969d6043e9465c883cb9f7363e78e8")
 				Expect(resourceGroupIdentityModel.ID).To(Equal(core.StringPtr("56969d6043e9465c883cb9f7363e78e8")))
 
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				Expect(hpcsKeyIdentityModel).ToNot(BeNil())
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
-				Expect(hpcsKeyIdentityModel.Crn).To(Equal(core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")))
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				Expect(gatewayMacsecCakKeyReferenceModel).ToNot(BeNil())
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				Expect(gatewayMacsecCakKeyReferenceModel.Crn).To(Equal(core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")))
 
 				// Construct an instance of the GatewayMacsecCakPrototype model
 				gatewayMacsecCakPrototypeModel := new(directlinkv1.GatewayMacsecCakPrototype)
 				Expect(gatewayMacsecCakPrototypeModel).ToNot(BeNil())
-				gatewayMacsecCakPrototypeModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPrototypeModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPrototypeModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPrototypeModel.Session = core.StringPtr("primary")
-				Expect(gatewayMacsecCakPrototypeModel.Key).To(Equal(hpcsKeyIdentityModel))
+				Expect(gatewayMacsecCakPrototypeModel.Key).To(Equal(gatewayMacsecCakKeyReferenceModel))
 				Expect(gatewayMacsecCakPrototypeModel.Name).To(Equal(core.StringPtr("1000")))
 				Expect(gatewayMacsecCakPrototypeModel.Session).To(Equal(core.StringPtr("primary")))
 
@@ -12119,7 +12120,7 @@ var _ = Describe(`DirectLinkV1`, func() {
 				Expect(err).To(BeNil())
 			})
 			It(`Invoke NewGatewayMacsecCakPrototype successfully`, func() {
-				var key *directlinkv1.HpcsKeyIdentity = nil
+				var key directlinkv1.GatewayMacsecCakKeyReferenceIntf = nil
 				name := "1000"
 				session := "primary"
 				_, err := directLinkService.NewGatewayMacsecCakPrototype(key, name, session)
@@ -12265,12 +12266,6 @@ var _ = Describe(`DirectLinkV1`, func() {
 				Expect(getPortOptionsModel).ToNot(BeNil())
 				Expect(getPortOptionsModel.ID).To(Equal(core.StringPtr("0a06fb9b-820f-4c44-8a31-77f1f0806d28")))
 				Expect(getPortOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
-			})
-			It(`Invoke NewHpcsKeyIdentity successfully`, func() {
-				crn := "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"
-				_model, err := directLinkService.NewHpcsKeyIdentity(crn)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
 			})
 			It(`Invoke NewListGatewayAsPrependsOptions successfully`, func() {
 				// Construct an instance of the ListGatewayAsPrependsOptions model
@@ -12491,19 +12486,19 @@ var _ = Describe(`DirectLinkV1`, func() {
 				Expect(err).To(BeNil())
 			})
 			It(`Invoke NewSetGatewayMacsecOptions successfully`, func() {
-				// Construct an instance of the HpcsKeyIdentity model
-				hpcsKeyIdentityModel := new(directlinkv1.HpcsKeyIdentity)
-				Expect(hpcsKeyIdentityModel).ToNot(BeNil())
-				hpcsKeyIdentityModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
-				Expect(hpcsKeyIdentityModel.Crn).To(Equal(core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")))
+				// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+				gatewayMacsecCakKeyReferenceModel := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+				Expect(gatewayMacsecCakKeyReferenceModel).ToNot(BeNil())
+				gatewayMacsecCakKeyReferenceModel.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+				Expect(gatewayMacsecCakKeyReferenceModel.Crn).To(Equal(core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")))
 
 				// Construct an instance of the GatewayMacsecCakPrototype model
 				gatewayMacsecCakPrototypeModel := new(directlinkv1.GatewayMacsecCakPrototype)
 				Expect(gatewayMacsecCakPrototypeModel).ToNot(BeNil())
-				gatewayMacsecCakPrototypeModel.Key = hpcsKeyIdentityModel
+				gatewayMacsecCakPrototypeModel.Key = gatewayMacsecCakKeyReferenceModel
 				gatewayMacsecCakPrototypeModel.Name = core.StringPtr("1000")
 				gatewayMacsecCakPrototypeModel.Session = core.StringPtr("primary")
-				Expect(gatewayMacsecCakPrototypeModel.Key).To(Equal(hpcsKeyIdentityModel))
+				Expect(gatewayMacsecCakPrototypeModel.Key).To(Equal(gatewayMacsecCakKeyReferenceModel))
 				Expect(gatewayMacsecCakPrototypeModel.Name).To(Equal(core.StringPtr("1000")))
 				Expect(gatewayMacsecCakPrototypeModel.Session).To(Equal(core.StringPtr("primary")))
 
@@ -12649,6 +12644,24 @@ var _ = Describe(`DirectLinkV1`, func() {
 			It(`Invoke NewAuthenticationKeyIdentityKeyProtectAuthenticationKeyIdentity successfully`, func() {
 				crn := "crn:v1:bluemix:public:kms:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"
 				_model, err := directLinkService.NewAuthenticationKeyIdentityKeyProtectAuthenticationKeyIdentity(crn)
+				Expect(_model).ToNot(BeNil())
+				Expect(err).To(BeNil())
+			})
+			It(`Invoke NewAuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity successfully`, func() {
+				crn := "crn:v1:bluemix:public:secrets-manager:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:secret:bbb222bc-430a-4de9-9aad-84e5bb022222"
+				_model, err := directLinkService.NewAuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity(crn)
+				Expect(_model).ToNot(BeNil())
+				Expect(err).To(BeNil())
+			})
+			It(`Invoke NewGatewayMacsecCakKeyReferenceHpcsCakKeyReference successfully`, func() {
+				crn := "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222"
+				_model, err := directLinkService.NewGatewayMacsecCakKeyReferenceHpcsCakKeyReference(crn)
+				Expect(_model).ToNot(BeNil())
+				Expect(err).To(BeNil())
+			})
+			It(`Invoke NewGatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference successfully`, func() {
+				crn := "crn:v1:bluemix:public:secrets-manager:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:secret:bbb222bc-430a-4de9-9aad-84e5bb022222"
+				_model, err := directLinkService.NewGatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference(crn)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})
@@ -12841,6 +12854,24 @@ var _ = Describe(`DirectLinkV1`, func() {
 
 			var result *directlinkv1.GatewayBfdPatchTemplate
 			err = directlinkv1.UnmarshalGatewayBfdPatchTemplate(raw, &result)
+			Expect(err).To(BeNil())
+			Expect(result).ToNot(BeNil())
+			Expect(result).To(Equal(model))
+		})
+		It(`Invoke UnmarshalGatewayMacsecCakKeyReference successfully`, func() {
+			// Construct an instance of the model.
+			model := new(directlinkv1.GatewayMacsecCakKeyReference)
+			model.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+
+			b, err := json.Marshal(model)
+			Expect(err).To(BeNil())
+
+			var raw map[string]json.RawMessage
+			err = json.Unmarshal(b, &raw)
+			Expect(err).To(BeNil())
+
+			var result *directlinkv1.GatewayMacsecCakKeyReference
+			err = directlinkv1.UnmarshalGatewayMacsecCakKeyReference(raw, &result)
 			Expect(err).To(BeNil())
 			Expect(result).ToNot(BeNil())
 			Expect(result).To(Equal(model))
@@ -13062,24 +13093,6 @@ var _ = Describe(`DirectLinkV1`, func() {
 			Expect(result).ToNot(BeNil())
 			Expect(result).To(Equal(model))
 		})
-		It(`Invoke UnmarshalHpcsKeyIdentity successfully`, func() {
-			// Construct an instance of the model.
-			model := new(directlinkv1.HpcsKeyIdentity)
-			model.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
-
-			b, err := json.Marshal(model)
-			Expect(err).To(BeNil())
-
-			var raw map[string]json.RawMessage
-			err = json.Unmarshal(b, &raw)
-			Expect(err).To(BeNil())
-
-			var result *directlinkv1.HpcsKeyIdentity
-			err = directlinkv1.UnmarshalHpcsKeyIdentity(raw, &result)
-			Expect(err).To(BeNil())
-			Expect(result).ToNot(BeNil())
-			Expect(result).To(Equal(model))
-		})
 		It(`Invoke UnmarshalResourceGroupIdentity successfully`, func() {
 			// Construct an instance of the model.
 			model := new(directlinkv1.ResourceGroupIdentity)
@@ -13194,6 +13207,24 @@ var _ = Describe(`DirectLinkV1`, func() {
 			Expect(result).ToNot(BeNil())
 			Expect(result).To(Equal(model))
 		})
+		It(`Invoke UnmarshalAuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity successfully`, func() {
+			// Construct an instance of the model.
+			model := new(directlinkv1.AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity)
+			model.Crn = core.StringPtr("crn:v1:bluemix:public:secrets-manager:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:secret:bbb222bc-430a-4de9-9aad-84e5bb022222")
+
+			b, err := json.Marshal(model)
+			Expect(err).To(BeNil())
+
+			var raw map[string]json.RawMessage
+			err = json.Unmarshal(b, &raw)
+			Expect(err).To(BeNil())
+
+			var result *directlinkv1.AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity
+			err = directlinkv1.UnmarshalAuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity(raw, &result)
+			Expect(err).To(BeNil())
+			Expect(result).ToNot(BeNil())
+			Expect(result).To(Equal(model))
+		})
 		It(`Invoke UnmarshalGatewayActionTemplateUpdatesItemGatewayClientBGPASNUpdate successfully`, func() {
 			// Construct an instance of the model.
 			model := new(directlinkv1.GatewayActionTemplateUpdatesItemGatewayClientBGPASNUpdate)
@@ -13263,6 +13294,42 @@ var _ = Describe(`DirectLinkV1`, func() {
 
 			var result *directlinkv1.GatewayActionTemplateUpdatesItemGatewayClientVLANUpdate
 			err = directlinkv1.UnmarshalGatewayActionTemplateUpdatesItemGatewayClientVLANUpdate(raw, &result)
+			Expect(err).To(BeNil())
+			Expect(result).ToNot(BeNil())
+			Expect(result).To(Equal(model))
+		})
+		It(`Invoke UnmarshalGatewayMacsecCakKeyReferenceHpcsCakKeyReference successfully`, func() {
+			// Construct an instance of the model.
+			model := new(directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference)
+			model.Crn = core.StringPtr("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
+
+			b, err := json.Marshal(model)
+			Expect(err).To(BeNil())
+
+			var raw map[string]json.RawMessage
+			err = json.Unmarshal(b, &raw)
+			Expect(err).To(BeNil())
+
+			var result *directlinkv1.GatewayMacsecCakKeyReferenceHpcsCakKeyReference
+			err = directlinkv1.UnmarshalGatewayMacsecCakKeyReferenceHpcsCakKeyReference(raw, &result)
+			Expect(err).To(BeNil())
+			Expect(result).ToNot(BeNil())
+			Expect(result).To(Equal(model))
+		})
+		It(`Invoke UnmarshalGatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference successfully`, func() {
+			// Construct an instance of the model.
+			model := new(directlinkv1.GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference)
+			model.Crn = core.StringPtr("crn:v1:bluemix:public:secrets-manager:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:secret:bbb222bc-430a-4de9-9aad-84e5bb022222")
+
+			b, err := json.Marshal(model)
+			Expect(err).To(BeNil())
+
+			var raw map[string]json.RawMessage
+			err = json.Unmarshal(b, &raw)
+			Expect(err).To(BeNil())
+
+			var result *directlinkv1.GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference
+			err = directlinkv1.UnmarshalGatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference(raw, &result)
 			Expect(err).To(BeNil())
 			Expect(result).ToNot(BeNil())
 			Expect(result).To(Equal(model))


### PR DESCRIPTION
## PR summary
This PR enables Secret Manager support for Direct Link in the Go SDK.

**Fixes:** Secret Manager Enablement for DL – [Issue #202](https://github.ibm.com/NetworkTribe/ui-cli-sdk-terraform-netserv/issues/202)

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->