### PR TITLE
fix(logpush): Remove incorrect required validation from optional fields

### DIFF
--- a/logpushjobsapiv1/logpush_jobs_api_v1.go
+++ b/logpushjobsapiv1/logpush_jobs_api_v1.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2024.
+ * (C) Copyright IBM Corp. 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.98.0-8be2046a-20241205-162752
+ * IBM OpenAPI SDK Code Generator Version: 3.114.0-a902401e-20260427-192904
  */
 
 // Package logpushjobsapiv1 : Operations and models for the LogpushJobsApiV1 service
@@ -225,12 +225,12 @@ func (logpushJobsApi *LogpushJobsApiV1) GetLogpushJobsV2WithContext(ctx context.
 		return
 	}
 
-	for headerName, headerValue := range getLogpushJobsV2Options.Headers {
+	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "GetLogpushJobsV2")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "GetLogpushJobsV2")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range getLogpushJobsV2Options.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -290,12 +290,12 @@ func (logpushJobsApi *LogpushJobsApiV1) CreateLogpushJobV2WithContext(ctx contex
 		return
 	}
 
-	for headerName, headerValue := range createLogpushJobV2Options.Headers {
+	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "CreateLogpushJobV2")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "CreateLogpushJobV2")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range createLogpushJobV2Options.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -370,12 +370,12 @@ func (logpushJobsApi *LogpushJobsApiV1) GetLogpushJobV2WithContext(ctx context.C
 		return
 	}
 
-	for headerName, headerValue := range getLogpushJobV2Options.Headers {
+	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "GetLogpushJobV2")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "GetLogpushJobV2")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range getLogpushJobV2Options.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -441,12 +441,12 @@ func (logpushJobsApi *LogpushJobsApiV1) UpdateLogpushJobV2WithContext(ctx contex
 		return
 	}
 
-	for headerName, headerValue := range updateLogpushJobV2Options.Headers {
+	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "UpdateLogpushJobV2")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "UpdateLogpushJobV2")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range updateLogpushJobV2Options.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -521,12 +521,12 @@ func (logpushJobsApi *LogpushJobsApiV1) DeleteLogpushJobV2WithContext(ctx contex
 		return
 	}
 
-	for headerName, headerValue := range deleteLogpushJobV2Options.Headers {
+	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "DeleteLogpushJobV2")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "DeleteLogpushJobV2")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range deleteLogpushJobV2Options.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -586,12 +586,12 @@ func (logpushJobsApi *LogpushJobsApiV1) GetLogpushOwnershipV2WithContext(ctx con
 		return
 	}
 
-	for headerName, headerValue := range getLogpushOwnershipV2Options.Headers {
+	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "GetLogpushOwnershipV2")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "GetLogpushOwnershipV2")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range getLogpushOwnershipV2Options.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -662,12 +662,12 @@ func (logpushJobsApi *LogpushJobsApiV1) ValidateLogpushOwnershipChallengeV2WithC
 		return
 	}
 
-	for headerName, headerValue := range validateLogpushOwnershipChallengeV2Options.Headers {
+	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "ValidateLogpushOwnershipChallengeV2")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "ValidateLogpushOwnershipChallengeV2")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range validateLogpushOwnershipChallengeV2Options.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -742,12 +742,12 @@ func (logpushJobsApi *LogpushJobsApiV1) ListFieldsForDatasetV2WithContext(ctx co
 		return
 	}
 
-	for headerName, headerValue := range listFieldsForDatasetV2Options.Headers {
+	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "ListFieldsForDatasetV2")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "ListFieldsForDatasetV2")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range listFieldsForDatasetV2Options.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -808,12 +808,12 @@ func (logpushJobsApi *LogpushJobsApiV1) ListLogpushJobsForDatasetV2WithContext(c
 		return
 	}
 
-	for headerName, headerValue := range listLogpushJobsForDatasetV2Options.Headers {
+	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "ListLogpushJobsForDatasetV2")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "ListLogpushJobsForDatasetV2")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range listLogpushJobsForDatasetV2Options.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -873,12 +873,12 @@ func (logpushJobsApi *LogpushJobsApiV1) GetLogsRetentionWithContext(ctx context.
 		return
 	}
 
-	for headerName, headerValue := range getLogsRetentionOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "GetLogsRetention")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "GetLogsRetention")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range getLogsRetentionOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -938,12 +938,12 @@ func (logpushJobsApi *LogpushJobsApiV1) CreateLogRetentionWithContext(ctx contex
 		return
 	}
 
-	for headerName, headerValue := range createLogRetentionOptions.Headers {
+	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "CreateLogRetention")
+	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("logpush_jobs_api", "V1", "CreateLogRetention")
-	for headerName, headerValue := range sdkHeaders {
+	for headerName, headerValue := range createLogRetentionOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
@@ -1792,13 +1792,13 @@ type LogpushJobPack struct {
 	DestinationConf *string `json:"destination_conf" validate:"required"`
 
 	// Records the last time for which logs have been successfully pushed.
-	LastComplete *string `json:"last_complete" validate:"required"`
+	LastComplete *string `json:"last_complete,omitempty"`
 
 	// Records the last time the job failed.
-	LastError *string `json:"last_error" validate:"required"`
+	LastError *string `json:"last_error,omitempty"`
 
 	// The last failure.
-	ErrorMessage *string `json:"error_message" validate:"required"`
+	ErrorMessage *string `json:"error_message,omitempty"`
 }
 
 // UnmarshalLogpushJobPack unmarshals an instance of LogpushJobPack from the specified map of raw messages.

--- a/logpushjobsapiv1/logpush_jobs_api_v1_integration_test.go
+++ b/logpushjobsapiv1/logpush_jobs_api_v1_integration_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -231,6 +231,70 @@ var _ = Describe(`LogpushJobsApiV1`, func() {
 					Enabled:         core.BoolPtr(false),
 					LogpullOptions:  core.StringPtr("timestamps=rfc3339&timestamps=rfc3339"),
 					DestinationConf: core.StringPtr("s3://mybucket/logs?region=us-west-1"),
+					Frequency:       core.StringPtr("high"),
+				}
+
+				updateOptions.SetUpdateLogpushJobV2Request(updateLogpushJobV2RequestGenericModel)
+
+				updateResult, updateResponse, updateErr := testService.UpdateLogpushJobV2(updateOptions)
+				Expect(updateErr).To(BeNil())
+				Expect(updateResponse).ToNot(BeNil())
+				Expect(updateResult).ToNot(BeNil())
+
+				//Delete Logpush Jobs
+				for _, thisJob := range allJobs {
+					delOptions := testService.NewDeleteLogpushJobV2Options(strconv.FormatInt(*thisJob.ID, 10))
+					delResult, delResponse, delErr := testService.DeleteLogpushJobV2(delOptions)
+					Expect(delErr).To(BeNil())
+					Expect(delResponse).ToNot(BeNil())
+					Expect(delResult).ToNot(BeNil())
+				}
+			})
+
+			It(`create/update/delete/get logpush jobs with custom HTTP destination`, func() {
+				shouldSkipTest()
+
+				options := testService.NewCreateLogpushJobV2Options()
+				createLogpushJobV2RequestGenericModel := &logpushjobsapiv1.CreateLogpushJobV2RequestLogpushJobGenericReq{
+					Name:            core.StringPtr("Test123"),
+					Enabled:         core.BoolPtr(false),
+					LogpullOptions:  core.StringPtr("fields=ClientIP,ClientRequestHost,ClientRequestMethod"),
+					DestinationConf: core.StringPtr("https://httpbin.org/post"),
+					Dataset:         core.StringPtr("http_requests"),
+					Frequency:       core.StringPtr("high"),
+				}
+
+				options.SetCreateLogpushJobV2Request(createLogpushJobV2RequestGenericModel)
+				result, response, operationErr := testService.CreateLogpushJobV2(options)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				job := result.Result
+
+				// List all Logpush Jobs
+				listOptions := testService.NewGetLogpushJobsV2Options()
+				getResult, getResponse, getErr := testService.GetLogpushJobsV2(listOptions)
+				Expect(getErr).To(BeNil())
+				Expect(getResponse).ToNot(BeNil())
+				Expect(getResult).ToNot(BeNil())
+
+				allJobs := getResult.Result
+
+				// Get Logpush Job by jobID
+				getJob := allJobs[0]
+				getOptions := testService.NewGetLogpushJobV2Options(strconv.FormatInt(*getJob.ID, 10))
+				result, response, operationErr = testService.GetLogpushJobV2(getOptions)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				//Update Logpush Jobs
+				updateOptions := testService.NewUpdateLogpushJobV2Options(strconv.FormatInt(*job.ID, 10))
+				updateLogpushJobV2RequestGenericModel := &logpushjobsapiv1.UpdateLogpushJobV2RequestLogpushJobsUpdateGenericReq{
+					Enabled:         core.BoolPtr(false),
+					LogpullOptions:  core.StringPtr("fields=ClientIP,ClientRequestHost"),
+					DestinationConf: core.StringPtr("https://httpbin.org/post"),
 					Frequency:       core.StringPtr("high"),
 				}
 

--- a/logpushjobsapiv1/logpush_jobs_api_v1_suite_test.go
+++ b/logpushjobsapiv1/logpush_jobs_api_v1_suite_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/logpushjobsapiv1/logpush_jobs_api_v1_test.go
+++ b/logpushjobsapiv1/logpush_jobs_api_v1_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2024.
+ * (C) Copyright IBM Corp. 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## PR summary
Fixes "unexpected EOF" error when retrieving logpush jobs configured with custom HTTP destinations. Optional fields in `LogpushJobPack` struct had incorrect `validate:"required"` tags, causing unmarshaling to fail when API returned null values.

**Fixes:** https://github.ibm.com/NetworkTribe/CIS_Support/issues/5296

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
SDK fails to parse API responses for logpush jobs with custom HTTP destinations when optional fields (`last_complete`, `last_error`, `error_message`) contain null values. Error: "unexpected EOF" with HTTP 200 status code.

## What is the new behavior?
SDK correctly handles null values in optional fields. Logpush jobs with custom HTTP destinations can be retrieved without errors. Fields are properly marked as optional with `omitempty` JSON tags instead of `validate:"required"`.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

## Other information
- Regenerated SDK with IBM OpenAPI SDK Generator v3.114.0
- All 98 unit tests pass
- No changes to public API surface
- Backward compatible with existing code
- Related: https://github.ibm.com/NetworkTribe/ui-cli-sdk-terraform-netserv/issues/565
